### PR TITLE
remove unnecessary copyright statement

### DIFF
--- a/skeleton/src/main.cpp
+++ b/skeleton/src/main.cpp
@@ -41,18 +41,3 @@ int main(int argc, const char* argv[]) {
   return r;
 }
 
-// ----------------------------------------------------------------------------
-// Copyright 2018 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------


### PR DESCRIPTION
The skeleton file is a trivial file that has nothing unique in it

CC: @kpfleming 