### PR TITLE
avoid fixup targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,19 +32,15 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${LLVM_INCLUDE_DIR}>
 )
-
-add_library( clangfixup INTERFACE IMPORTED )
-set_property(
-  TARGET clangfixup
-  APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CLANG_INCLUDE_DIRS}
+target_include_directories(
+  clangmetatool
+  SYSTEM PRIVATE
+  ${CLANG_INCLUDE_DIRS}
 )
 
 target_link_libraries(
   clangmetatool
-  PUBLIC
   clangTooling
-  PRIVATE
-  clangfixup
 )
 
 install(

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -6,10 +6,6 @@ configure_file(
   include/clangmetatool-testconfig.h
 )
 
-add_library( gtestfixup INTERFACE IMPORTED )
-set_property( TARGET gtestfixup
-    APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${GTEST_INCLUDE_DIRS} )
-
 foreach(
   TEST
   001-meta-tool
@@ -37,13 +33,18 @@ foreach(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${LLVM_INCLUDE_DIR}>
   )
+  target_include_directories(
+    ${TEST}.t
+    SYSTEM
+    PRIVATE
+    ${CLANG_INCLUDE_DIRS}
+    ${GTEST_INCLUDE_DIRS}
+  )
 
   target_link_libraries(
     ${TEST}.t
     clangmetatool
     clangTooling
-    clangfixup
-    gtestfixup
     ${GTEST_BOTH_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
   )


### PR DESCRIPTION
They ended up leaking to the cmake export interface and that was not intended

Signed-off-by: Daniel Ruoso <druoso@bloomberg.net>