### PR TITLE
Integer constant propagation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   src/definitions/definitions.cpp
 
   src/propagation/constant_cstring_propagator.cpp
+  src/propagation/constant_integer_propagator.cpp
   src/propagation/strongly_connected_blocks.cpp
   src/propagation/types/value_context_ordering.cpp
   src/propagation/util/get_stmt_from_cfg_element.cpp

--- a/README.md
+++ b/README.md
@@ -109,10 +109,15 @@ Another part of this consists of constant propagators to assist
 with analysis. Those will be in the `clangmetatool::propagation`
 namespace.
 
-More specifically, the current implementation provides a constant
-C-style string propagator, which propagates constant strings through
-the control flow graph so that `char*` variables may be queried for there
-true value anywhere where that value is deterministic.
+More specifically, the current implementation provides propagation for the 
+follwing types so that variables may be queried for their true values anywhere
+within the control-flow, so long as the value is deterministic:
+
+* Constant C-style string propagator, which propagates constant strings through
+the control flow graph
+
+* Constant integer propagation which propagates integer values through the code
+considering references, pointers, const-ness of `int` & `int`-like types
 
 This could be useful for various purposes but especially for identifing
 things like which database a function is actually calling out to, etc.

--- a/include/clangmetatool/propagation/constant_integer_propagator.h
+++ b/include/clangmetatool/propagation/constant_integer_propagator.h
@@ -2,7 +2,7 @@
 #define INCLUDED_CLANGMETATOOL_PROPAGATION_CONSTANT_INTEGER_PROPAGATOR_H
 
 #include <iostream>
-#include <string>
+#include <cstdint>
 
 #include <clangmetatool/propagation/propagation_result.h>
 
@@ -25,8 +25,8 @@ class ConstantIntegerPropagatorImpl;
 
 /**
  * ConstantIntegerPropagator is a tool to run a propagation
- * over the string variables that are used within functions
- * and attempt to determine the string values of those
+ * over integer variables that are used within functions
+ * and attempt to determine the integer values of those
  * variables.
  *
  * The analysis runs once per function even if runPropagation
@@ -63,7 +63,7 @@ public:
    * PropagationResult will return true for a call to `isUnresolved()` if a
    * deterministic value cannot be determined for the variable.
    */
-  PropagationResult<std::string> runPropagation
+  PropagationResult<std::intmax_t> runPropagation
   (const clang::FunctionDecl* function, const clang::DeclRefExpr* variable);
 
   /**

--- a/include/clangmetatool/propagation/constant_integer_propagator.h
+++ b/include/clangmetatool/propagation/constant_integer_propagator.h
@@ -1,0 +1,95 @@
+#ifndef INCLUDED_CLANGMETATOOL_PROPAGATION_CONSTANT_INTEGER_PROPAGATOR_H
+#define INCLUDED_CLANGMETATOOL_PROPAGATION_CONSTANT_INTEGER_PROPAGATOR_H
+
+#include <iostream>
+#include <string>
+
+#include <clangmetatool/propagation/propagation_result.h>
+
+/**
+ * Forward declarations for clang types
+ */
+namespace clang {
+  class CompilerInstance;
+  class DeclRefExpr;
+  class FunctionDecl;
+}
+
+namespace clangmetatool {
+namespace propagation {
+
+/**
+ * Forward declaration to implementation details of the propagator.
+ */
+class ConstantIntegerPropagatorImpl;
+
+/**
+ * ConstantIntegerPropagator is a tool to run a propagation
+ * over the string variables that are used within functions
+ * and attempt to determine the string values of those
+ * variables.
+ *
+ * The analysis runs once per function even if runPropagation
+ * is called multiple times.
+ *
+ * It is also important to note that this analysis assumes
+ * that all loops will only be be run through the first time
+ * and effectively ignores any changes that may be made from
+ * reentering a block from the loop.
+ */
+class ConstantIntegerPropagator {
+private:
+  /**
+    * Pointer to implementation.
+    */
+  ConstantIntegerPropagatorImpl* impl;
+
+public:
+  /**
+   * Explicit constructor to allow for implementation details.
+   *    - ci is a pointer to an instance of the clang compiler
+   */
+  ConstantIntegerPropagator(const clang::CompilerInstance* ci);
+
+  /**
+    * Explicit destructor.
+    */
+  ~ConstantIntegerPropagator();
+
+  /**
+   * Given the surrounding function and the usage of a int
+   * holding variable, attempt to determine the value held by that variable.
+   *
+   * PropagationResult will return true for a call to `isUnresolved()` if a
+   * deterministic value cannot be determined for the variable.
+   */
+  PropagationResult<std::string> runPropagation
+  (const clang::FunctionDecl* function, const clang::DeclRefExpr* variable);
+
+  /**
+   * Print out the variable contexts for all the functions that have
+   * been propagated.
+   */
+  void dump(std::ostream& stream) const;
+};
+
+} // namespace propagation
+} // namespace clangmetatool
+
+#endif
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/src/propagation/constant_integer_propagator.cpp
+++ b/src/propagation/constant_integer_propagator.cpp
@@ -1,0 +1,155 @@
+#include "propagation_visitor.h"
+#include "constant_propagator.h"
+
+#include <clangmetatool/propagation/constant_integer_propagator.h>
+
+#include <string>
+
+#include <clang/Analysis/CFG.h>
+#include <clang/AST/Expr.h>
+
+namespace clangmetatool {
+namespace propagation {
+namespace {
+
+// Given a type, determine if it is a int
+bool isIntegerType(const clang::Type* T) {
+  return T->getPointeeType().getTypePtr()->isIntegerType();
+}
+
+// Utility class to visit the statements of a block and update the
+// ValueContextMap in the process
+class IntegerVisitor : public PropagationVisitor<IntegerVisitor, std::string> {
+private:
+  // Given an expression, try to evaluate it to a int result. Return
+  // false if this is not possible
+  bool evalExprToInteger(std::string& result, const clang::Expr* E) {
+    // We only care about char types
+    if(isIntegerType(E->getType().getTypePtr())) {
+      clang::Expr::EvalResult ER;
+
+      if(E->isEvaluatable(context) && E->EvaluateAsRValue(ER, context)) {
+        std::string r = ER.Val.getAsString(context, E->getType());
+
+        // So long as the string is not null
+        if("0" != r) {
+          // Clang returns results as &"actual-string"[0]
+          result = r.substr(2, r.length() - 6);
+
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+public:
+  // Use parent class's constructor
+  using PropagationVisitor<IntegerVisitor, std::string>::PropagationVisitor;
+
+  // Visit a declaration of a variable
+  void VisitDeclStmt(const clang::DeclStmt* DS) {
+    for(auto D : DS->decls()) {
+      if(clang::Decl::Var == D->getKind()) {
+        auto VD = reinterpret_cast<const clang::VarDecl*>(D);
+
+        // Only the local non-static variables are possibly deterministic
+        if(VD->isLocalVarDecl() && VD->hasLocalStorage()) {
+          if(VD->hasInit()) {
+            auto I = VD->getInit();
+
+            std::string result;
+
+            if(evalExprToInteger(result, I)) {
+              // If the variable is a string, add it to the map
+              addToMap(VD->getNameAsString(), result, VD->getLocStart());
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Visit a binary operator
+  void VisitBinaryOperator(const clang::BinaryOperator* BO) {
+    // We only care about assignments (=) in this context
+    if(clang::BO_Assign == BO->getOpcode()) {
+      if(clang::Stmt::DeclRefExprClass == BO->getLHS()->getStmtClass()) {
+        auto LHS = reinterpret_cast<const clang::DeclRefExpr*>(BO->getLHS());
+
+        std::string result;
+
+        if(evalExprToInteger(result, BO->getRHS())) {
+            // If we can evaluate the expression to a string add the result
+            // to the context map
+            addToMap(LHS->getNameInfo().getAsString(), result, BO->getLocStart());
+        } else {
+            // Otherwise, mark the variable as UNRESOLVED after this point
+            addToMap(LHS->getNameInfo().getAsString(), {}, BO->getLocStart());
+        }
+      }
+    }
+  }
+
+  // Visit a function call
+  void VisitCallExpr(const clang::CallExpr* CE) {
+    for(auto A : CE->arguments()) {
+      auto base = A->IgnoreImpCasts();
+
+      if(clang::Stmt::DeclRefExprClass == base->getStmtClass()) {
+        auto DR = reinterpret_cast<const clang::DeclRefExpr*>(base);
+
+        if(isIntegerType(DR->getType().getTypePtr())) {
+          // If the variable is a char*, mark it as UNRESOLVED
+          addToMap(DR->getNameInfo().getAsString(), {}, CE->getLocEnd());
+        }
+      }
+    }
+  }
+};
+
+} // namespace anonymous
+
+class ConstantIntegerPropagatorImpl : public ConstantPropagator<IntegerVisitor> {
+public:
+  ConstantIntegerPropagatorImpl(const clang::CompilerInstance* ci)
+    : ConstantPropagator<IntegerVisitor>(ci) {
+  }
+};
+
+ConstantIntegerPropagator::ConstantIntegerPropagator(const clang::CompilerInstance* ci) {
+  impl = new ConstantIntegerPropagatorImpl(ci);
+}
+
+ConstantIntegerPropagator::~ConstantIntegerPropagator() {
+  delete impl;
+}
+
+PropagationResult<std::string> ConstantIntegerPropagator::runPropagation
+(const clang::FunctionDecl* function, const clang::DeclRefExpr* variable) {
+  return impl->runPropagation(function, variable);
+}
+
+void ConstantIntegerPropagator::dump(std::ostream& stream) const {
+  impl->dump(stream);
+}
+
+} // namespace propagation
+} // namespace clangmetatool
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/src/propagation/constant_integer_propagator.cpp
+++ b/src/propagation/constant_integer_propagator.cpp
@@ -43,6 +43,13 @@ private:
     return false;
   }
 
+  bool evalCompoundExprToInteger(std::string& result, const clang::Expr* E) {
+    llvm::APSInt ER;
+    E->EvaluateAsInt(ER, context);
+    result = ER.toString(10);
+    return true;
+  }
+
 public:
   // Use parent class's constructor
   using PropagationVisitor<IntegerVisitor, std::string>::PropagationVisitor;
@@ -95,7 +102,7 @@ public:
 
         std::string result;
 
-        if(evalExprToInteger(result, BO)) {
+        if(evalCompoundExprToInteger(result, BO)) {
             // If we can evaluate the expression to a string add the result
             // to the context map
             addToMap(LHS->getNameInfo().getAsString(), result, BO->getLocStart());

--- a/t/019-basic-integer-propagation.t.cpp
+++ b/t/019-basic-integer-propagation.t.cpp
@@ -1,0 +1,133 @@
+#include "clangmetatool-testconfig.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/propagation/constant_integer_propagator.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace clang::ast_matchers;
+
+using FindVarDeclsDatum = std::pair<const clang::FunctionDecl*, const clang::DeclRefExpr*>;
+using FindVarDeclsData  = std::vector<FindVarDeclsDatum>;
+
+class FindVarDeclsCallback : public MatchFinder::MatchCallback {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDeclsData* data;
+
+public:
+  FindVarDeclsCallback(clang::CompilerInstance* ci, FindVarDeclsData* data)
+    : ci(ci), data(data) {
+  }
+
+  virtual void run(const MatchFinder::MatchResult& r) override {
+    const clang::FunctionDecl* f = r.Nodes.getNodeAs<clang::FunctionDecl>("func");
+
+    const clang::DeclRefExpr* d = r.Nodes.getNodeAs<clang::DeclRefExpr>("declRef");
+
+    data->push_back({f, d});
+  }
+};
+
+class FindVarDecls {
+private:
+  FindVarDeclsData data;
+
+  StatementMatcher matcher =
+    (declRefExpr
+     (hasDeclaration
+      (varDecl
+       (hasAnyName
+        (
+         "v1"
+        )
+       )
+      ),
+      hasAncestor(
+       functionDecl().bind("func")
+      )
+     )
+    ).bind("declRef");
+
+  FindVarDeclsCallback callback;
+
+public:
+  FindVarDecls(clang::CompilerInstance* ci,
+               MatchFinder*             f)
+    : callback(ci, &data)
+  {
+    f->addMatcher(matcher, &callback);
+  }
+
+  FindVarDeclsData* getData() { return &data; }
+};
+
+class MyTool {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDecls fvd;
+  clangmetatool::propagation::ConstantIntegerPropagator csp;
+
+public:
+  MyTool(clang::CompilerInstance* ci, MatchFinder *f)
+    : ci(ci), fvd(ci, f), csp(ci) {
+  }
+
+  void postProcessing
+  (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+      FAIL();
+  }
+};
+
+} // namespace anonymous
+
+TEST(propagation_ConstantIntegerPropagation, basic) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+  int argc = 4;
+  const char* argv[] = {
+    "foo",
+    CMAKE_SOURCE_DIR "/t/data/019-basic-integer-propagation/main.c",
+    "--",
+    "-xc"
+  };
+  clang::tooling::CommonOptionsParser optionsParser
+    (argc, argv, MyToolCategory);
+  clang::tooling::RefactoringTool tool
+    (optionsParser.getCompilations(), optionsParser.getSourcePathList());
+  clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>
+    raf(tool.getReplacements());
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/020-function-args-integer-propagation.t.cpp
+++ b/t/020-function-args-integer-propagation.t.cpp
@@ -104,12 +104,11 @@ public:
     const char* expectedResult =
       "main >>>>>>>>>>>>>>>>>>>>>>>>>>\n"
       "  ** v1\n"
-      "    - 6:3 '0' (Changed by code)\n"
-      "    - 13:3 '1' (Changed by code)\n"
-      "    - 16:3 '<UNRESOLVED>' (Changed by code)\n"
-      "    - 18:3 '2' (Changed by code)\n"
-      "    - 20:3 '<UNRESOLVED>' (Changed by code)\n"
-      " "
+      "    - 9:3 '0' (Changed by code)\n"
+      "    - 17:3 '1' (Changed by code)\n"
+      "    - 21:3 '<UNRESOLVED>' (Changed by code)\n"
+      "    - 23:3 '2' (Changed by code)\n"
+      "    - 26:3 '<UNRESOLVED>' (Changed by code)\n"
       "main <<<<<<<<<<<<<<<<<<<<<<<<<<\n";
 
     EXPECT_STREQ(expectedResult, stream.str().c_str());

--- a/t/020-function-args-integer-propagation.t.cpp
+++ b/t/020-function-args-integer-propagation.t.cpp
@@ -104,10 +104,12 @@ public:
     const char* expectedResult =
       "main >>>>>>>>>>>>>>>>>>>>>>>>>>\n"
       "  ** v1\n"
-      "    - 4:3 '0' (Changed by code)\n"
-      "    - 9:3 '42' (Changed by code)\n"
-      "    - 21:3 '<UNRESOLVED>' (Changed by code)\n"
-      "    - 31:3 '42' (Changed by code)\n"
+      "    - 6:3 '0' (Changed by code)\n"
+      "    - 13:3 '1' (Changed by code)\n"
+      "    - 16:3 '<UNRESOLVED>' (Changed by code)\n"
+      "    - 18:3 '2' (Changed by code)\n"
+      "    - 20:3 '<UNRESOLVED>' (Changed by code)\n"
+      " "
       "main <<<<<<<<<<<<<<<<<<<<<<<<<<\n";
 
     EXPECT_STREQ(expectedResult, stream.str().c_str());
@@ -116,14 +118,15 @@ public:
 
 } // namespace anonymous
 
-TEST(propagation_ConstantIntegerPropagation, basic) {
+TEST(propagation_ConstantIntegerPropagation, functionArgs) {
   llvm::cl::OptionCategory MyToolCategory("my-tool options");
   int argc = 4;
   const char* argv[] = {
     "foo",
-    CMAKE_SOURCE_DIR "/t/data/019-basic-integer-propagation/main.c",
+    CMAKE_SOURCE_DIR "/t/data/020-function-args-integer-propagation/main.cpp",
     "--",
-    "-xc"
+    // Test C++ for confirming that this works on a superset
+    "-xc++"
   };
   clang::tooling::CommonOptionsParser optionsParser
     (argc, argv, MyToolCategory);

--- a/t/021-branching-integer-propagation.t.cpp
+++ b/t/021-branching-integer-propagation.t.cpp
@@ -1,0 +1,162 @@
+#include "clangmetatool-testconfig.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/propagation/constant_integer_propagator.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace clang::ast_matchers;
+
+using FindVarDeclsDatum = std::pair<const clang::FunctionDecl*, const clang::DeclRefExpr*>;
+using FindVarDeclsData  = std::vector<FindVarDeclsDatum>;
+
+class FindVarDeclsCallback : public MatchFinder::MatchCallback {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDeclsData* data;
+
+public:
+  FindVarDeclsCallback(clang::CompilerInstance* ci, FindVarDeclsData* data)
+    : ci(ci), data(data) {
+  }
+
+  virtual void run(const MatchFinder::MatchResult& r) override {
+    const clang::FunctionDecl* f = r.Nodes.getNodeAs<clang::FunctionDecl>("func");
+
+    const clang::DeclRefExpr* d = r.Nodes.getNodeAs<clang::DeclRefExpr>("declRef");
+
+    data->push_back({f, d});
+  }
+};
+
+class FindVarDecls {
+private:
+  FindVarDeclsData data;
+
+  StatementMatcher matcher =
+    (declRefExpr
+     (hasDeclaration
+      (varDecl
+       (hasAnyName
+        (
+         "v1"
+        )
+       )
+      ),
+      hasAncestor(
+       functionDecl().bind("func")
+      )
+     )
+    ).bind("declRef");
+
+  FindVarDeclsCallback callback;
+
+public:
+  FindVarDecls(clang::CompilerInstance* ci,
+               MatchFinder*             f)
+    : callback(ci, &data)
+  {
+    f->addMatcher(matcher, &callback);
+  }
+
+  FindVarDeclsData* getData() { return &data; }
+};
+
+class MyTool {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDecls fvd;
+  clangmetatool::propagation::ConstantIntegerPropagator cip;
+
+public:
+  MyTool(clang::CompilerInstance* ci, MatchFinder *f)
+    : ci(ci), fvd(ci, f), cip(ci) {
+  }
+
+  void postProcessing
+  (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+    FindVarDeclsData* decls = fvd.getData();
+
+    for(auto decl : *decls) {
+      cip.runPropagation(decl.first, decl.second);
+    }
+
+    std::ostringstream stream;
+
+    cip.dump(stream);
+
+    const char* expectedResult =
+      "main >>>>>>>>>>>>>>>>>>>>>>>>>>\n"
+      "  ** v1\n"
+      "    - 5:3 '1' (Changed by code)\n"
+      "    - 16:3 '0' (Changed by code)\n"
+      "  ** v2\n"
+      "    - 6:3 '2' (Changed by code)\n"
+      "    - 11:5 '5' (Changed by code)\n"
+      "    - 13:5 '2' (Control flow merge)\n"
+      "    - 16:3 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v3\n"
+      "    - 7:3 '3' (Changed by code)\n"
+      "    - 13:5 '6' (Changed by code)\n"
+      "    - 16:3 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v4\n"
+      "    - 8:3 '4' (Changed by code)\n"
+      "main <<<<<<<<<<<<<<<<<<<<<<<<<<\n";
+
+    EXPECT_STREQ(expectedResult, stream.str().c_str());
+  }
+};
+
+} // namespace anonymous
+
+TEST(propagation_ConstantIntegerPropagation, functionArgs) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+  int argc = 4;
+  const char* argv[] = {
+    "foo",
+    CMAKE_SOURCE_DIR "/t/data/021-branching-integer-propagation/main.c",
+    "--",
+    // Test C++ for confirming that this works on a superset
+    "-xc"
+  };
+  clang::tooling::CommonOptionsParser optionsParser
+    (argc, argv, MyToolCategory);
+  clang::tooling::RefactoringTool tool
+    (optionsParser.getCompilations(), optionsParser.getSourcePathList());
+  clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>
+    raf(tool.getReplacements());
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/022-looping-integer-propagation.t.cpp
+++ b/t/022-looping-integer-propagation.t.cpp
@@ -1,0 +1,164 @@
+#include "clangmetatool-testconfig.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/propagation/constant_integer_propagator.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace clang::ast_matchers;
+
+using FindVarDeclsDatum = std::pair<const clang::FunctionDecl*, const clang::DeclRefExpr*>;
+using FindVarDeclsData  = std::vector<FindVarDeclsDatum>;
+
+class FindVarDeclsCallback : public MatchFinder::MatchCallback {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDeclsData* data;
+
+public:
+  FindVarDeclsCallback(clang::CompilerInstance* ci, FindVarDeclsData* data)
+    : ci(ci), data(data) {
+  }
+
+  virtual void run(const MatchFinder::MatchResult& r) override {
+    const clang::FunctionDecl* f = r.Nodes.getNodeAs<clang::FunctionDecl>("func");
+
+    const clang::DeclRefExpr* d = r.Nodes.getNodeAs<clang::DeclRefExpr>("declRef");
+
+    data->push_back({f, d});
+  }
+};
+
+class FindVarDecls {
+private:
+  FindVarDeclsData data;
+
+  StatementMatcher matcher =
+    (declRefExpr
+     (hasDeclaration
+      (varDecl
+       (hasAnyName
+        (
+         "v1"
+        )
+       )
+      ),
+      hasAncestor(
+       functionDecl().bind("func")
+      )
+     )
+    ).bind("declRef");
+
+  FindVarDeclsCallback callback;
+
+public:
+  FindVarDecls(clang::CompilerInstance* ci,
+               MatchFinder*             f)
+    : callback(ci, &data)
+  {
+    f->addMatcher(matcher, &callback);
+  }
+
+  FindVarDeclsData* getData() { return &data; }
+};
+
+class MyTool {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDecls fvd;
+  clangmetatool::propagation::ConstantIntegerPropagator cip;
+
+public:
+  MyTool(clang::CompilerInstance* ci, MatchFinder *f)
+    : ci(ci), fvd(ci, f), cip(ci) {
+  }
+
+  void postProcessing
+  (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+    FindVarDeclsData* decls = fvd.getData();
+
+    for(auto decl : *decls) {
+      cip.runPropagation(decl.first, decl.second);
+    }
+
+    std::ostringstream stream;
+
+    cip.dump(stream);
+
+    const char* expectedResult =
+      "main >>>>>>>>>>>>>>>>>>>>>>>>>>\n"
+      "  ** i\n"
+      "    - 14:7 '0' (Changed by code)\n"
+      "  ** v1\n"
+      "    - 5:3 '1' (Changed by code)\n"
+      "    - 18:3 '0' (Changed by code)\n"
+      "  ** v2\n"
+      "    - 6:3 '2' (Changed by code)\n"
+      "    - 11:5 '5' (Changed by code)\n"
+      "    - 14:7 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v3\n"
+      "    - 7:3 '3' (Changed by code)\n"
+      "    - 15:5 '6' (Changed by code)\n"
+      "    - 18:3 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v4\n"
+      "    - 8:3 '4' (Changed by code)\n"
+      "    - 21:5 '7' (Changed by code)\n"
+      "main <<<<<<<<<<<<<<<<<<<<<<<<<<\n";
+
+    EXPECT_STREQ(expectedResult, stream.str().c_str());
+  }
+};
+
+} // namespace anonymous
+
+TEST(propagation_ConstantIntegerPropagation, functionArgs) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+  int argc = 4;
+  const char* argv[] = {
+    "foo",
+    CMAKE_SOURCE_DIR "/t/data/022-looping-integer-propagation/main.c",
+    "--",
+    // Test C++ for confirming that this works on a superset
+    "-xc"
+  };
+  clang::tooling::CommonOptionsParser optionsParser
+    (argc, argv, MyToolCategory);
+  clang::tooling::RefactoringTool tool
+    (optionsParser.getCompilations(), optionsParser.getSourcePathList());
+  clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>
+    raf(tool.getReplacements());
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/023-multi-function-integer-propagation.t.cpp
+++ b/t/023-multi-function-integer-propagation.t.cpp
@@ -1,0 +1,173 @@
+#include "clangmetatool-testconfig.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/propagation/constant_integer_propagator.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace clang::ast_matchers;
+
+using FindVarDeclsDatum = std::pair<const clang::FunctionDecl*, const clang::DeclRefExpr*>;
+using FindVarDeclsData  = std::vector<FindVarDeclsDatum>;
+
+class FindVarDeclsCallback : public MatchFinder::MatchCallback {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDeclsData* data;
+
+public:
+  FindVarDeclsCallback(clang::CompilerInstance* ci, FindVarDeclsData* data)
+    : ci(ci), data(data) {
+  }
+
+  virtual void run(const MatchFinder::MatchResult& r) override {
+    const clang::FunctionDecl* f = r.Nodes.getNodeAs<clang::FunctionDecl>("func");
+
+    const clang::DeclRefExpr* d = r.Nodes.getNodeAs<clang::DeclRefExpr>("declRef");
+
+    data->push_back({f, d});
+  }
+};
+
+class FindVarDecls {
+private:
+  FindVarDeclsData data;
+
+  StatementMatcher matcher =
+    (declRefExpr
+     (hasDeclaration
+      (varDecl
+       (hasAnyName
+        (
+         "v1"
+        )
+       )
+      ),
+      hasAncestor(
+       functionDecl().bind("func")
+      )
+     )
+    ).bind("declRef");
+
+  FindVarDeclsCallback callback;
+
+public:
+  FindVarDecls(clang::CompilerInstance* ci,
+               MatchFinder*             f)
+    : callback(ci, &data)
+  {
+    f->addMatcher(matcher, &callback);
+  }
+
+  FindVarDeclsData* getData() { return &data; }
+};
+
+class MyTool {
+private:
+  clang::CompilerInstance* ci;
+  FindVarDecls fvd;
+  clangmetatool::propagation::ConstantIntegerPropagator cip;
+
+public:
+  MyTool(clang::CompilerInstance* ci, MatchFinder *f)
+    : ci(ci), fvd(ci, f), cip(ci) {
+  }
+
+  void postProcessing
+  (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+    FindVarDeclsData* decls = fvd.getData();
+
+    for(auto decl : *decls) {
+      cip.runPropagation(decl.first, decl.second);
+    }
+
+    std::ostringstream stream;
+
+    cip.dump(stream);
+
+    const char* expectedResult =
+      "bar >>>>>>>>>>>>>>>>>>>>>>>>>>\n"
+      "  ** v1\n"
+      "    - 4:3 '10' (Changed by code)\n"
+      "    - 13:5 '14' (Changed by code)\n"
+      "    - 16:3 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v2\n"
+      "    - 5:3 '11' (Changed by code)\n"
+      "  ** v3\n"
+      "    - 6:3 '12' (Changed by code)\n"
+      "    - 10:3 '13' (Changed by code)\n"
+      "bar <<<<<<<<<<<<<<<<<<<<<<<<<<\n"
+      "main >>>>>>>>>>>>>>>>>>>>>>>>>>\n"
+      "  ** v1\n"
+      "    - 20:3 '1' (Changed by code)\n"
+      "    - 31:3 '0' (Changed by code)\n"
+      "  ** v2\n"
+      "    - 21:3 '2' (Changed by code)\n"
+      "    - 26:5 '5' (Changed by code)\n"
+      "    - 28:5 '2' (Control flow merge)\n"
+      "    - 31:3 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v3\n"
+      "    - 22:3 '3' (Changed by code)\n"
+      "    - 28:5 '6' (Changed by code)\n"
+      "    - 31:3 '<UNRESOLVED>' (Control flow merge)\n"
+      "  ** v4\n"
+      "    - 23:3 '4' (Changed by code)\n"
+      "main <<<<<<<<<<<<<<<<<<<<<<<<<<\n";
+
+    EXPECT_STREQ(expectedResult, stream.str().c_str());
+  }
+};
+
+} // namespace anonymous
+
+TEST(propagation_ConstantIntegerPropagation, functionArgs) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+  int argc = 4;
+  const char* argv[] = {
+    "foo",
+    CMAKE_SOURCE_DIR "/t/data/023-multi-function-integer-propagation/main.c",
+    "--",
+    // Test C++ for confirming that this works on a superset
+    "-xc"
+  };
+  clang::tooling::CommonOptionsParser optionsParser
+    (argc, argv, MyToolCategory);
+  clang::tooling::RefactoringTool tool
+    (optionsParser.getCompilations(), optionsParser.getSourcePathList());
+  clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>
+    raf(tool.getReplacements());
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -28,6 +28,9 @@ foreach(
   018-multi-function-cstring-propagation
   019-basic-integer-propagation
   020-function-args-integer-propagation
+  021-branching-integer-propagation
+  022-looping-integer-propagation
+  023-multi-function-integer-propagation
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -27,6 +27,7 @@ foreach(
   017-looping-cstring-propagation
   018-multi-function-cstring-propagation
   019-basic-integer-propagation
+  020-function-args-integer-propagation
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -26,6 +26,7 @@ foreach(
   016-branching-cstring-propagation
   017-looping-cstring-propagation
   018-multi-function-cstring-propagation
+  019-basic-integer-propagation
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/data/019-basic-integer-propagation/main.c
+++ b/t/data/019-basic-integer-propagation/main.c
@@ -1,5 +1,4 @@
 int foo(int);
-int bar(char*);
 
 int main(int argc, char* argv[]) {
   int v1 = 0;
@@ -12,6 +11,23 @@ int main(int argc, char* argv[]) {
   // These do nothing due to ints being passed by value
   foo(v1);
 
-  // This also doesn't change this scope's v1
-  bar(v1);
+  v1 += 2;
+  v1 *= 3;
+  v1 /= 4;
+  v1 -= 5;
+
+  // Cannot resolve v1 to a value deterministically (from this point on)
+  // The next few instances of unresolved will be compressed into a single one
+  v1 = foo(6);
+
+  // All of these are non-deterministic too, due to dependending on a v1's
+  // history
+  v1 += 1;
+  v1 -= 1;
+  v1 *= 1;
+  v1 /= 1;
+
+  // Restore balance to the universe
+  v1 = 42;
+  return 0;
 }

--- a/t/data/019-basic-integer-propagation/main.c
+++ b/t/data/019-basic-integer-propagation/main.c
@@ -1,0 +1,17 @@
+int foo(int);
+int bar(char*);
+
+int main(int argc, char* argv[]) {
+  int v1 = 0;
+
+  // v1 retains its old value in this current scope
+  foo(v1);
+
+  v1 = 42;
+
+  // These do nothing due to ints being passed by value
+  foo(v1);
+
+  // This also doesn't change this scope's v1
+  bar(v1);
+}

--- a/t/data/020-function-args-integer-propagation/main.cpp
+++ b/t/data/020-function-args-integer-propagation/main.cpp
@@ -1,0 +1,23 @@
+int foo(int);
+int bar(int*);
+int qux(int&);
+
+int main(int argc, char* argv[]) {
+  int v1 = 0;
+
+  // v1 retains its old value in this current scope
+  // Due to pass by value semantics
+  // This is ignored by the propagator
+  foo(v1);
+
+  v1 = 1;
+
+  // Passed as pointer, v1 might change inside bar(int*)
+  bar(&v1);
+
+  v1 = 2;
+
+  qux(v1);
+
+  return 0;
+}

--- a/t/data/020-function-args-integer-propagation/main.cpp
+++ b/t/data/020-function-args-integer-propagation/main.cpp
@@ -1,5 +1,8 @@
+int faa(const int);
 int foo(int);
+int boo(const int*);
 int bar(int*);
+int baz(const int&);
 int qux(int&);
 
 int main(int argc, char* argv[]) {
@@ -8,15 +11,18 @@ int main(int argc, char* argv[]) {
   // v1 retains its old value in this current scope
   // Due to pass by value semantics
   // This is ignored by the propagator
+  faa(v1);
   foo(v1);
 
   v1 = 1;
 
   // Passed as pointer, v1 might change inside bar(int*)
+  boo(&v1);
   bar(&v1);
 
   v1 = 2;
 
+  baz(v1);
   qux(v1);
 
   return 0;

--- a/t/data/021-branching-integer-propagation/main.c
+++ b/t/data/021-branching-integer-propagation/main.c
@@ -1,0 +1,20 @@
+int foo(int);
+int bar(int);
+
+int main(int argc, char* argv[]) {
+  int v1 = 1;
+  int v2 = 2;
+  int v3 = 3;
+  int v4 = 4;
+
+  if(4 == foo(v1)) {
+    v2 = 5;
+  } else {
+    v3 = 6;
+  }
+
+  v1 = 0;
+
+  foo(v4);
+  bar(v1);
+}

--- a/t/data/022-looping-integer-propagation/main.c
+++ b/t/data/022-looping-integer-propagation/main.c
@@ -1,0 +1,23 @@
+int foo(int);
+int bar();
+
+int main(int argc, char* argv[]) {
+  int v1 = 1;
+  short v2 = 2;
+  long v3 = 3;
+  unsigned int v4 = 4;
+
+  while(4 == foo(v1)) {
+    v2 = 5;
+  }
+
+  for(int i = 0; i < 12; ++i) {
+    v3 = 6;
+  }
+
+  v1 = 0;
+
+  do {
+    v4 = 7;
+  } while(foo(v3) == bar());
+}

--- a/t/data/023-multi-function-integer-propagation/main.c
+++ b/t/data/023-multi-function-integer-propagation/main.c
@@ -1,0 +1,35 @@
+int foo(int);
+
+int bar(int baz) {
+  int v1 = 10;
+  int v2 = 11;
+  int v3 = 12;
+
+  foo(v1);
+
+  v3 = 13;
+
+  if(foo(v2)) {
+    v1 = 14;
+  }
+
+  return 1337;
+}
+
+int main(int argc, char* argv[]) {
+  int v1 = 1;
+  int v2 = 2;
+  int v3 = 3;
+  int v4 = 4;
+
+  if(4 == foo(v1)) {
+    v2 = 5;
+  } else {
+    v3 = 6;
+  }
+
+  v1 = 0;
+
+  foo(v4);
+  bar(v1);
+}


### PR DESCRIPTION
## TODO

Cases considered
- [x] Assignment to `int` types
- [x] `<UNRESOLVED>` when passed to `foo(int*)`
- [x] `<UNRESOLVED>` when passed to `foo(int&)`
- [x] const qualified pointers and references must be skipped