### PR TITLE
Run perl from PATH

### DIFF
--- a/cmake/clangmetatool-find-clang-include-dir.pl
+++ b/cmake/clangmetatool-find-clang-include-dir.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use IO::Handle;


### PR DESCRIPTION
Perl may not be in /usr/bin/perl, run it from PATH instead.

CC: @ruoso, @burz 