### PR TITLE
Find clang installation if referenced via symlink

### DIFF
--- a/cmake/clangmetatool-find-clang-include-dir.pl
+++ b/cmake/clangmetatool-find-clang-include-dir.pl
@@ -5,8 +5,10 @@ use IO::Handle;
 use IPC::Open3;
 use POSIX qw<dup2>;
 use File::Spec::Functions;
+use Cwd qw(realpath);
 
 my $clang_path = shift @ARGV;
+$clang_path = realpath($clang_path);
 
 my ($p_r, $p_w);
 pipe($p_r, $p_w)


### PR DESCRIPTION
**Describe your changes**
The clangmetatool cmake module tries to find the standard include directories for a clang installation, but it fails if clang is referenced via symlink.

**Testing performed**
Test changes against project using clang referenced via symlink

CC: @ruoso 