### PR TITLE
Use the same compile flags as LLVM when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ add_library(
   src/propagation/types/value_context_ordering.cpp
   src/propagation/util/get_stmt_from_cfg_element.cpp
 )
+
+# Use the same flags that LLVM used to compile
+list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+include(AddLLVM)
+llvm_update_compile_flags(clangmetatool)
+
 target_include_directories(
   clangmetatool
   PUBLIC


### PR DESCRIPTION
Closes #36 

**Describe your changes**
Use the compile flags in the LLVM config when building clangmetatool. This mostly affects RTTI and exception support.

**Testing performed**
Built clangmetatool and application that depends on clangmetatool. Checked that if LLVM is configured without `-DLLVM_ENABLE_RTTI=1`, then clangmetatool has RTTI off as well.

CC: @ruoso 
