### PR TITLE
Add in more commonly used utilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ matrix:
           compiler: gcc
           language: cpp
           sudo: true
-          script: docker build --build-arg BASE_IMAGE=ubuntu:18.04 --build-arg IMAGE_REPO=bionic --build-arg TARGET_LLVM_VERSION=7 .
-        - os: linux
-          compiler: gcc
-          language: cpp
-          sudo: true
           script: docker build --build-arg BASE_IMAGE=ubuntu:18.10 --build-arg IMAGE_REPO=cosmic --build-arg TARGET_LLVM_VERSION=8 .
         - os: linux
           compiler: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(
   src/collectors/definitions.cpp
   src/collectors/find_calls.cpp
   src/collectors/find_cxx_member_calls.cpp
+  src/collectors/find_functions.cpp
   src/collectors/include_graph/find_decl_match_callback.cpp
   src/collectors/include_graph/find_decl_ref_match_callback.cpp
   src/collectors/include_graph/find_type_match_callback.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@ file(RELATIVE_PATH CLANG_CMAKE_RELATIVE_DIR ${CMAKE_INSTALL_PREFIX}
 add_library(
   clangmetatool
 
-  src/tool_application_support.cpp
-
   src/include_graph_dependencies.cpp
+  src/source_util.cpp
+  src/tool_application_support.cpp
 
   src/collectors/definitions.cpp
   src/collectors/find_calls.cpp

--- a/include/clangmetatool/collectors/find_functions.h
+++ b/include/clangmetatool/collectors/find_functions.h
@@ -1,0 +1,85 @@
+#ifndef INCLUDED_CLANGMETATOOL_COLLECTORS_FIND_FUNCTIONS_H
+#define INCLUDED_CLANGMETATOOL_COLLECTORS_FIND_FUNCTIONS_H
+
+#include <vector>
+
+namespace clang {
+
+class CompilerInstance;
+class FunctionDecl;
+
+namespace ast_matchers {
+
+class MatchFinder;
+
+} // namespace ast_matchers
+
+} // namespace clang
+
+namespace clangmetatool {
+namespace collectors {
+
+/**
+ * The data collected by the FindFunctions collector
+ */
+using FindFunctionsData = std::vector<const clang::FunctionDecl *>;
+
+/**
+ * Forward declaration to the implementation details of the
+ * collector.
+ */
+class FindFunctionsImpl;
+
+/**
+ * FindFunctions data collector. Collects all the functions that
+ * are defined within a source unit. This includes anonymous/static
+ * functions but not functions defined in macros or functions that
+ * are declared "extern"
+ */
+class FindFunctions {
+private:
+  /**
+   * Pointer to implementation
+   */
+  FindFunctionsImpl *impl;
+
+public:
+  /**
+   * Explicit constructor, to allow for implementation details:
+   *    - ci is a pointer to an instance of the clang compiler
+   *    - f is a pointer to an instance of the MatchFinder class
+   */
+  FindFunctions(clang::CompilerInstance *ci,
+                clang::ast_matchers::MatchFinder *f);
+
+  /**
+   * Explicit destructor.
+   */
+  ~FindFunctions();
+
+  /**
+   * Get the pointer to the data structure, populated or not
+   */
+  const FindFunctionsData *getData() const;
+};
+
+} // namespace collectors
+} // namespace clangmetatool
+
+#endif
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/include/clangmetatool/match_forwarder.h
+++ b/include/clangmetatool/match_forwarder.h
@@ -1,0 +1,69 @@
+#ifndef INCLUDED_CLANGMETATOOL_MATCH_FORWARDER_H
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+#include <functional>
+#include <list>
+
+namespace clangmetatool {
+
+/**
+ * Forwards clang matches to a function object, allowing one to handle matches
+ * without creating a new class for each.
+ */
+class MatchForwarder {
+public:
+  typedef clang::ast_matchers::MatchFinder::MatchResult ResultType;
+  typedef std::function<void(const ResultType &result)> FunctionType;
+
+private:
+  class MatchCallback : public clang::ast_matchers::MatchFinder::MatchCallback {
+  private:
+    FunctionType d_function;
+
+  public:
+    MatchCallback(const FunctionType &function) : d_function(function) {}
+
+    virtual void run(const ResultType &result) override { d_function(result); }
+  };
+
+  clang::ast_matchers::MatchFinder *d_matchFinder_p;
+  std::list<MatchCallback> d_callbacks;
+
+public:
+  /**
+   * Create a forwarder that wraps the given match finder.
+   */
+  MatchForwarder(clang::ast_matchers::MatchFinder *matchFinder)
+      : d_matchFinder_p(matchFinder) {}
+
+  /**
+   * Add the given matcher to the match finder. When a match is found, the
+   * result will be forwarded to the given function.
+   */
+  template <typename MatchType>
+  void addMatcher(const MatchType &match, const FunctionType &function) {
+    d_callbacks.emplace_back(function);
+    d_matchFinder_p->addMatcher(match, &d_callbacks.back());
+  }
+};
+
+} // namespace clangmetatool
+
+#endif
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/include/clangmetatool/source_util.h
+++ b/include/clangmetatool/source_util.h
@@ -1,0 +1,119 @@
+#ifndef INCLUDED_CLANGMETATOOL_SOURCE_UTIL_H
+#define INCLUDED_CLANGMETATOOL_SOURCE_UTIL_H
+
+#include <clang/AST/Stmt.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Lex/Preprocessor.h>
+
+#include <ostream>
+#include <string>
+
+namespace clangmetatool {
+
+/**
+ * Namespace for common clang source-related utilities
+ */
+struct SourceUtil {
+  /**
+   * Record describing a region of code
+   */
+  struct Region {
+    std::string d_filename;
+    int d_line = -1;
+    int d_column = -1;
+    int d_length = -1;
+  };
+
+  /**
+   * Expand the given range by resolving macros and iterating past tokens.
+   */
+  static clang::CharSourceRange
+  expandRange(const clang::SourceRange &range,
+              const clang::SourceManager &sourceManager);
+
+  /**
+   * Return a range for the given statement, using the given source manager to
+   * locate code. The range will point to the location after expanding macros.
+   */
+  static clang::CharSourceRange
+  getRangeForStatement(const clang::Stmt &statement,
+                       const clang::SourceManager &sourceManager);
+
+  /**
+   * Return the source code for the given statement, using the given source
+   * manager to locate code.
+   */
+  static std::string
+  getSourceForStatement(const clang::Stmt &statement,
+                        const clang::SourceManager &sourceManager);
+
+  /**
+   * Return the macro name used in the given statement, using the given source
+   * manager to locate code, or an empty string if the statement does not
+   * contain a macro.
+   */
+  static std::string
+  getMacroNameForStatement(const clang::Stmt &statement,
+                           const clang::SourceManager &sourceManager);
+
+  /**
+   * Return a record describing the given region, using the given source
+   * manager to locate code
+   */
+  static Region getRegionForRange(clang::CharSourceRange range,
+                                  const clang::SourceManager &sourceManager);
+
+  /**
+   * Return a record describing the region for the given statement, using the
+   * given source manager to locate code.
+   */
+  static Region
+  getRegionForStatement(const clang::Stmt &statement,
+                        const clang::SourceManager &sourceManager);
+
+  /**
+   * Return true if the given statement is partially contained in a macro,
+   * using the given source manager to locate code.
+   */
+  static bool isPartialMacro(const clang::SourceRange &sourceRange,
+                             const clang::SourceManager &sourceManager,
+                             clang::Preprocessor &preprocessor);
+};
+
+/**
+ * Compare two regions and return 'true' if they point to the same location.
+ */
+bool operator==(const SourceUtil::Region &lhs, const SourceUtil::Region &rhs);
+
+/**
+ * Compare two regions and return 'true' if they do not point to the same
+ * location.
+ */
+bool operator!=(const SourceUtil::Region &lhs, const SourceUtil::Region &rhs);
+
+/**
+ * Write the given region to the given stream in a human-readable format.
+ */
+std::ostream &operator<<(std::ostream &stream,
+                         const SourceUtil::Region &region);
+
+} // namespace clangmetatool
+
+#endif
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/src/collectors/find_functions.cpp
+++ b/src/collectors/find_functions.cpp
@@ -1,0 +1,81 @@
+#include <clangmetatool/collectors/find_functions.h>
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+namespace clangmetatool {
+namespace collectors {
+
+using namespace clang::ast_matchers;
+
+namespace {
+
+class AnnotateFunction : public MatchFinder::MatchCallback {
+private:
+  clang::CompilerInstance *ci;
+  FindFunctionsData *data;
+
+public:
+  AnnotateFunction(clang::CompilerInstance *ci, FindFunctionsData *data)
+      : ci(ci), data(data) {}
+
+  virtual void run(const MatchFinder::MatchResult &r) override {
+    const clang::FunctionDecl *f =
+        r.Nodes.getNodeAs<clang::FunctionDecl>("func");
+
+    // Don't match macros/macro expansions or things declared extern
+    if (!f->getBeginLoc().isMacroID() &&
+        clang::SC_Extern != f->getStorageClass()) {
+      data->push_back(f);
+    }
+  }
+};
+
+} // anonymous namespace
+
+class FindFunctionsImpl {
+private:
+  FindFunctionsData data;
+
+  DeclarationMatcher dm = functionDecl(isExpansionInMainFile()).bind("func");
+
+  AnnotateFunction af;
+
+public:
+  FindFunctionsImpl(clang::CompilerInstance *ci,
+                    clang::ast_matchers::MatchFinder *f)
+      : af(ci, &data) {
+    f->addMatcher(dm, &af);
+  }
+
+  const FindFunctionsData *getData() const { return &data; }
+};
+
+FindFunctions::FindFunctions(clang::CompilerInstance *ci,
+                             clang::ast_matchers::MatchFinder *f) {
+  impl = new FindFunctionsImpl(ci, f);
+}
+
+FindFunctions::~FindFunctions() { delete impl; }
+
+const FindFunctionsData *FindFunctions::getData() const {
+  return impl->getData();
+}
+
+} // namespace collectors
+} // namespace clangmetatool
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/src/source_util.cpp
+++ b/src/source_util.cpp
@@ -1,0 +1,351 @@
+#include <clangmetatool/source_util.h>
+
+#include <clang/Basic/IdentifierTable.h>
+#include <clang/Basic/LangOptions.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Basic/SourceManager.h>
+#include <clang/Basic/TokenKinds.h>
+#include <clang/Lex/Lexer.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/Preprocessor.h>
+#include <clang/Lex/Token.h>
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/StringRef.h>
+
+#include <algorithm>
+#include <cassert>
+
+namespace clangmetatool {
+
+namespace {
+const clang::MacroInfo *getMacroInfo(clang::SourceLocation location,
+                                     const clang::SourceManager &sourceManager,
+                                     clang::Preprocessor &preprocessor) {
+  // Get macro identifier for the given location
+
+  llvm::StringRef macroName = preprocessor.getImmediateMacroName(location);
+  if (macroName.empty()) {
+    return nullptr;
+  }
+
+  clang::IdentifierInfo *macroId = preprocessor.getIdentifierInfo(macroName);
+  if (!macroId) {
+    return nullptr;
+  }
+
+  // The macro may have been redefined, so we need to search through history
+  // by location.
+
+  clang::MacroDirective *history =
+      preprocessor.getLocalMacroDirectiveHistory(macroId);
+  if (!history) {
+    return nullptr;
+  }
+
+  return history->findDirectiveAtLoc(location, sourceManager).getMacroInfo();
+}
+
+llvm::ArrayRef<clang::Token>
+getMacroTokens(clang::SourceLocation location,
+               const clang::SourceManager &sourceManager,
+               clang::Preprocessor &preprocessor) {
+  // Get macro identifier for the given location
+  auto *macroInfo = getMacroInfo(location, sourceManager, preprocessor);
+  return macroInfo ? macroInfo->tokens() : llvm::ArrayRef<clang::Token>();
+}
+
+bool sourceRangeContainsOnly(clang::SourceLocation beginLocation,
+                             clang::SourceLocation endLocation,
+                             const std::string &allowed,
+                             const clang::SourceManager &sourceManager) {
+  for (const char *it = sourceManager.getCharacterData(beginLocation),
+                  *end = sourceManager.getCharacterData(endLocation);
+       it != end; ++it) {
+    if (*it == '\\') {
+      ++it;
+      if (it == end && !(*it == '\n' || *it == '\r')) {
+        return false;
+      }
+    } else if (allowed.find(*it) == std::string::npos) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Find the first r-paren token that balances the l-paren at the beginning of
+// the list. If no such token exists, return a past the end iterator
+llvm::ArrayRef<clang::Token>::const_iterator
+skipToBalancedRParenTok(llvm::ArrayRef<clang::Token>::const_iterator begin,
+                        llvm::ArrayRef<clang::Token>::const_iterator end,
+                        const clang::SourceManager &SM) {
+  if (begin == end) {
+    return end;
+  }
+
+  assert(begin->is(clang::tok::l_paren) &&
+         "First iterator must point to an lparen token! ");
+
+  int leftBalance = 0;
+  clang::LangOptions langOpts;
+
+  // If there is an l_paren token after 'start':
+  // find the r_paren that balances it within that
+  // subexpression.
+  for (auto it = begin; it != end; ++it) {
+    if (it->is(clang::tok::l_paren)) {
+      ++leftBalance;
+    } else if (it->is(clang::tok::r_paren)) {
+      --leftBalance;
+    }
+
+    // If balanced, return the iterator pointing to the r-paren
+    if (leftBalance == 0) {
+      return it;
+    }
+  }
+
+  // Default to returning the end iterator in case we never hit 0 balance in
+  // the preceeding loop
+  return end;
+}
+
+} // namespace
+
+clang::CharSourceRange
+SourceUtil::expandRange(const clang::SourceRange &range,
+                        const clang::SourceManager &sourceManager) {
+  // Get the start location, resolving from macro definition to macro call
+  // location. Special handling is needed for a statement in a macro body, we
+  // want to resolve to the entire macro call.
+
+  clang::SourceLocation begin = range.getBegin();
+  if (sourceManager.isMacroBodyExpansion(begin)) {
+    begin = sourceManager.getExpansionRange(begin).getBegin();
+  } else {
+    begin = sourceManager.getFileLoc(begin);
+  }
+
+  // Get the end location, resolving from macro definition to macro call
+  // location. The end location of a statement points to the beginning of the
+  // last token in it, so we must use the lexer to traverse the token too.
+
+  clang::SourceLocation end = range.getEnd();
+  if (sourceManager.isMacroBodyExpansion(end)) {
+    end = sourceManager.getExpansionRange(end).getEnd();
+  } else {
+    end = sourceManager.getFileLoc(end);
+  }
+  end = clang::Lexer::getLocForEndOfToken(end, 0, sourceManager,
+                                          clang::LangOptions());
+
+  return clang::CharSourceRange::getCharRange(begin, end);
+}
+
+clang::CharSourceRange
+SourceUtil::getRangeForStatement(const clang::Stmt &statement,
+                                 const clang::SourceManager &sourceManager) {
+  return expandRange(statement.getSourceRange(), sourceManager);
+}
+
+std::string
+SourceUtil::getSourceForStatement(const clang::Stmt &statement,
+                                  const clang::SourceManager &sourceManager) {
+  clang::CharSourceRange sourceRange =
+      getRangeForStatement(statement, sourceManager);
+  auto text = clang::Lexer::getSourceText(sourceRange, sourceManager,
+                                          clang::LangOptions());
+  // If used incorrectly, or on an 'implicit' element getSourceText will return
+  // an empty string. This was probably unintentional. Fail fast
+  assert(!text.empty() && "Lexer::getSourceText returned an empty string!");
+  return text;
+}
+
+std::string SourceUtil::getMacroNameForStatement(
+    const clang::Stmt &statement, const clang::SourceManager &sourceManager) {
+  if (sourceManager.isMacroBodyExpansion(statement.getBeginLoc())) {
+    return clang::Lexer::getImmediateMacroName(
+               statement.getBeginLoc(), sourceManager, clang::LangOptions())
+        .str();
+  } else {
+    return std::string();
+  }
+}
+
+SourceUtil::Region
+SourceUtil::getRegionForRange(clang::CharSourceRange range,
+                              const clang::SourceManager &sourceManager) {
+  clang::SourceLocation begin = range.getBegin();
+  clang::SourceLocation end = range.getEnd();
+
+  // Create and return a record.
+
+  Region newRegion = {};
+
+  // Get filename without path
+
+  std::string filename =
+      sourceManager.getFilename(sourceManager.getSpellingLoc(begin)).str();
+  std::string::size_type sep = filename.rfind('/');
+  if (std::string::npos != sep) {
+    filename.erase(0, sep + 1);
+  }
+
+  newRegion.d_filename = filename;
+  newRegion.d_line = sourceManager.getSpellingLineNumber(begin);
+  newRegion.d_column = sourceManager.getSpellingColumnNumber(begin);
+  newRegion.d_length = sourceManager.getCharacterData(end) -
+                       sourceManager.getCharacterData(begin);
+  return newRegion;
+}
+
+SourceUtil::Region
+SourceUtil::getRegionForStatement(const clang::Stmt &statement,
+                                  const clang::SourceManager &sourceManager) {
+  clang::CharSourceRange sourceRange =
+      getRangeForStatement(statement, sourceManager);
+  return getRegionForRange(sourceRange, sourceManager);
+}
+
+bool SourceUtil::isPartialMacro(const clang::SourceRange &sourceRange,
+                                const clang::SourceManager &sourceManager,
+                                clang::Preprocessor &preprocessor) {
+  // Trace through levels of macros that are expanded by the beginning of
+  // the statement.
+
+  clang::SourceLocation begin = sourceRange.getBegin();
+
+  while (begin.isMacroID()) {
+    // Only process macros where the statement is in the body, not ones where
+    // it is an argument.
+
+    if (sourceManager.isMacroBodyExpansion(begin)) {
+      // Check that there are only spaces or '(' between the beginning of the
+      // macro and part corresponding to the beginning of the statement.
+
+      llvm::ArrayRef<clang::Token> tokens =
+          getMacroTokens(begin, sourceManager, preprocessor);
+      if (!tokens.empty()) {
+        clang::SourceLocation macroStart = tokens.front().getLocation();
+        clang::SourceLocation statementStart =
+            sourceManager.getSpellingLoc(begin);
+
+        if (!sourceRangeContainsOnly(macroStart, statementStart, " \t(",
+                                     sourceManager)) {
+          return true;
+        }
+      }
+    }
+
+    // Move up one level closer to the expansion point
+
+    begin = sourceManager.getImmediateMacroCallerLoc(begin);
+  }
+
+  // Trace through levels of macros that are expanded by the end of the
+  // statement.
+
+  clang::SourceLocation end = sourceRange.getEnd();
+  const clang::MacroInfo *prevMacro = nullptr;
+
+  while (end.isMacroID()) {
+    // Only process macros where the statement is in the body, not ones where
+    // it is an argument.
+
+    // Get information about the caller macro that was last expanded
+
+    const clang::MacroInfo *currentMacro =
+        getMacroInfo(end, sourceManager, preprocessor);
+
+    if (sourceManager.isMacroBodyExpansion(end)) {
+
+      // Tokens for the current macro's spelling, this only contains the tokens
+      // for its definition, included unexpanded identifiers
+      llvm::ArrayRef<clang::Token> currentMacroDefTokens =
+          currentMacro->tokens();
+      if (!currentMacroDefTokens.empty()) {
+        clang::SourceLocation macroEnd =
+            currentMacroDefTokens.back().getEndLoc();
+        clang::SourceLocation statementEnd = sourceManager.getSpellingLoc(end);
+
+        statementEnd = clang::Lexer::getLocForEndOfToken(
+            statementEnd, 0, sourceManager, clang::LangOptions());
+
+        // If we are expanding a function like macro, move statementEnd to
+        // match the clang::tok::TokenKind::r_paren corresponding to the
+        // opening clang::tok::TokenKind::l_paren
+
+        if (prevMacro && prevMacro->isFunctionLike()) {
+          // Find the first, if any l_paren token
+          auto *lparenIt = std::find_if(
+              currentMacroDefTokens.begin(), currentMacroDefTokens.end(),
+              [&sourceManager, &statementEnd](auto token) {
+                return sourceManager.isBeforeInTranslationUnit(
+                           statementEnd,
+                           clang::Lexer::getLocForEndOfToken(
+                               token.getEndLoc(), 0, sourceManager,
+                               clang::LangOptions())) &&
+                       token.is(clang::tok::l_paren);
+              });
+
+          auto *rparenIt = skipToBalancedRParenTok(
+              lparenIt, currentMacroDefTokens.end(), sourceManager);
+          if (rparenIt != lparenIt) {
+            statementEnd = clang::Lexer::getLocForEndOfToken(
+                rparenIt->getEndLoc(), 0, sourceManager, clang::LangOptions());
+          }
+        }
+
+        // Check that there are only spaces or ')' between the part
+        // corresponding to the end of the statement and the end of the macro.
+
+        if (!sourceRangeContainsOnly(statementEnd, macroEnd, " \t)",
+                                     sourceManager)) {
+          return true;
+        }
+      }
+    }
+
+    // Move up one level closer to the expansion point
+
+    end = sourceManager.getImmediateMacroCallerLoc(end);
+    prevMacro = currentMacro;
+  }
+
+  return false;
+}
+
+bool operator==(const SourceUtil::Region &lhs, const SourceUtil::Region &rhs) {
+  return lhs.d_line == rhs.d_line && lhs.d_column == rhs.d_column &&
+         lhs.d_length == rhs.d_length && lhs.d_filename == rhs.d_filename;
+}
+
+bool operator!=(const SourceUtil::Region &lhs, const SourceUtil::Region &rhs) {
+  return !(lhs == rhs);
+}
+
+std::ostream &operator<<(std::ostream &stream,
+                         const SourceUtil::Region &region) {
+  stream << "{ " << region.d_filename << ", " << region.d_line << ", "
+         << region.d_column << ", " << region.d_length << " }";
+  return stream;
+}
+
+} // namespace clangmetatool
+
+// ----------------------------------------------------------------------------
+// Copyright 2020 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/032-find-functions.t.cpp
+++ b/t/032-find-functions.t.cpp
@@ -87,7 +87,6 @@ TEST(FindFunctions, functions) {
   EXPECT_TRUE(fns->end() != fns->find("yolo_ono"));
 }
 
-
 // ----------------------------------------------------------------------------
 // Copyright 2018 Bloomberg Finance L.P.
 //

--- a/t/032-find-functions.t.cpp
+++ b/t/032-find-functions.t.cpp
@@ -1,0 +1,105 @@
+#include "clangmetatool-testconfig.h"
+
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/collectors/find_functions.h>
+
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+
+namespace {
+
+class MyTool {
+public:
+  using Container = std::unordered_set<std::string>;
+  using ArgTypes = std::shared_ptr<Container>;
+
+private:
+  clang::CompilerInstance* ci;
+  clangmetatool::collectors::FindFunctions ff;
+  ArgTypes fns;
+
+public:
+  MyTool(clang::CompilerInstance* ci, clang::ast_matchers::MatchFinder *f,
+         ArgTypes fns)
+    :ci(ci), ff(ci, f), fns(fns) {}
+
+  void postProcessing
+    (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+    for (const auto& fn : *ff.getData()) {
+      fns->insert(fn->getQualifiedNameAsString());
+    }
+  }
+};
+
+void runTool(const std::string& file, MyTool::ArgTypes& fns) {
+  std::string fullPath = CMAKE_SOURCE_DIR "/t/data/032-find-functions/" + file;
+  
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+
+  int argc = 4;
+  const char* argv[] = {
+    "foo",
+    fullPath.c_str(),
+    "--",
+    "-xc++"
+  };
+
+  clang::tooling::CommonOptionsParser
+    optionsParser
+    ( argc, argv,
+      MyToolCategory );
+  clang::tooling::RefactoringTool tool
+    ( optionsParser.getCompilations(),
+      optionsParser.getSourcePathList());
+
+  clangmetatool::MetaToolFactory< clangmetatool::MetaTool<MyTool> >
+    raf(tool.getReplacements(), fns);
+
+  int r = tool.run(&raf);
+  ASSERT_EQ(0, r);
+}
+
+} // anonymous namespace
+
+TEST(FindFunctions, functions) {
+  MyTool::ArgTypes fns = std::make_shared<MyTool::Container>();
+
+  runTool("functions.cpp", fns);
+
+  ASSERT_EQ(7, fns->size());
+  EXPECT_TRUE(fns->end() != fns->find("foo2"));
+  EXPECT_TRUE(fns->end() != fns->find("foo3"));
+  EXPECT_TRUE(fns->end() != fns->find("foo::bar"));
+  EXPECT_TRUE(fns->end() != fns->find("foobar"));
+  EXPECT_TRUE(fns->end() != fns->find("mwahaha"));
+  EXPECT_TRUE(fns->end() != fns->find("yolo::bar"));
+  EXPECT_TRUE(fns->end() != fns->find("yolo_ono"));
+}
+
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -48,6 +48,7 @@ foreach(
   029-tool-application-support
   030-cstring-propagation-bug
   031-validate-include-graph
+  032-find-functions
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/data/032-find-functions/functions.cpp
+++ b/t/data/032-find-functions/functions.cpp
@@ -1,0 +1,41 @@
+#include "includes_and_macros.h"
+
+extern int foobar2(int lol);
+
+SPEC(45)
+
+int foobar(char b) {
+  print(b);
+  print(yolo45());
+  return TO_INT(b);
+}
+
+int yolo_ono(int yeet);
+
+int yolo_ono(int yeet) {
+  return 1337 * yeet;
+}
+
+namespace foo {
+
+int bar() { return 4324; }
+
+}
+
+namespace yolo {
+
+int bar() { return 4325; }
+
+}
+
+int mwahaha() {
+  return foobar(23 && "ME");
+}
+
+char foo2() {
+  return 0;
+}
+
+long foo3(long long ll) {
+  return 0;
+}

--- a/t/data/032-find-functions/includes_and_macros.h
+++ b/t/data/032-find-functions/includes_and_macros.h
@@ -1,0 +1,6 @@
+#define TO_INT(b) (int) b
+
+void print(char b);
+
+#define SPEC(a) \
+  int yolo ## a() { return a; }


### PR DESCRIPTION
**Describe your changes**
Added:
* `FindFunctions` to find the functions that are declared within source units.
* `SourceUtil` for commonly used source-related functionality not provided by LibTooling itself
* `MatchForwarder` to forward matches to function objects so that classes are not necessary
    each individual type of match.

**Testing performed**
Added tests for `FindFunctions`.

@ruoso @dbeer1 @azeemba 
