### PR TITLE
Resolve realpath of executable in verifyInstallation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ matrix:
           compiler: gcc
           language: cpp
           sudo: true
-          script: docker build --build-arg BASE_IMAGE=ubuntu:18.10 --build-arg IMAGE_REPO=cosmic --build-arg TARGET_LLVM_VERSION=8 .
+          script: docker build --build-arg TARGET_LLVM_VERSION=8 .
         - os: linux
           compiler: gcc
           language: cpp
           sudo: true
-          script: docker build --build-arg BASE_IMAGE=ubuntu:19.04 --build-arg IMAGE_REPO=disco --build-arg TARGET_LLVM_VERSION=9 .
+          script: docker build --build-arg TARGET_LLVM_VERSION=9 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG BASE_IMAGE=ubuntu:18.10
+ARG BASE_IMAGE=ubuntu:18.04
 
 FROM $BASE_IMAGE
 
 ARG TARGET_LLVM_VERSION=8
-ARG IMAGE_REPO=cosmic
+ARG IMAGE_REPO=bionic
 
 # Depenedencies to fetch, build llvm and clang
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
**Describe your changes**
Always resolve the realpath of the executable found when using `verifyInstallation()`. Clang does not try to resolve symbolic links before trying to find the resource directory, which can result in failures to initialize the tool.

**Testing performed**
Tested locally with a previously failing project.