### PR TITLE
Add support for clang 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,8 @@ matrix:
           language: cpp
           sudo: true
           script: docker build --build-arg TARGET_LLVM_VERSION=9 .
+        - os: linux
+          compiler: gcc
+          language: cpp
+          sudo: true
+          script: docker build --build-arg TARGET_LLVM_VERSION=10 .

--- a/include/clangmetatool/meta_tool_factory.h
+++ b/include/clangmetatool/meta_tool_factory.h
@@ -2,6 +2,7 @@
 #define INCLUDED_CLANGMETATOOL_META_TOOL_FACTORY_H
 
 #include <map>
+#include <memory>
 #include <string>
 
 #include <clang/Frontend/FrontendAction.h>
@@ -45,7 +46,13 @@ public:
    * This will create the object of your tool giving the
    * replacemnets map as an argument.
    */
+#if LLVM_VERSION_MAJOR >= 10
+  virtual std::unique_ptr<clang::FrontendAction> create() {
+    return std::make_unique<T>(replacements, args);
+  }
+#else
   virtual clang::FrontendAction *create() { return new T(replacements, args); }
+#endif
 };
 } // namespace clangmetatool
 


### PR DESCRIPTION
Signed-off-by: Daniel Beer <dbeer1@bloomberg.net>

DRQS 157422622

**Describe your changes**
Add support for clang 10 to clangmetatool

**Testing performed**
Built and tested with clang 10.

**Additional context**
We seem to have gotten hit by a bug or possibly just a behavior change in the ordering of `CFGElement`s in a `CFGBlock` when moving to clang 10. Just a note that others have seen this issue as well for example in https://bugzilla.mozilla.org/show_bug.cgi?id=1580260
