### PR TITLE
Fix bug in `SourceUtil::getMacroNameForStatement`

### DIFF
--- a/src/source_util.cpp
+++ b/src/source_util.cpp
@@ -164,7 +164,9 @@ SourceUtil::getSourceForStatement(const clang::Stmt &statement,
 
 std::string SourceUtil::getMacroNameForStatement(
     const clang::Stmt &statement, const clang::SourceManager &sourceManager) {
-  if (sourceManager.isMacroBodyExpansion(statement.getBeginLoc())) {
+  clang::SourceLocation loc = statement.getBeginLoc();
+
+  if (loc.isMacroID()) {
     return clang::Lexer::getImmediateMacroName(
                statement.getBeginLoc(), sourceManager, clang::LangOptions())
         .str();

--- a/t/034-macro-name-for-statement.t.cpp
+++ b/t/034-macro-name-for-statement.t.cpp
@@ -1,0 +1,102 @@
+#include "clangmetatool-testconfig.h"
+
+#include <functional>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <utility>
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+#include <clang/Basic/SourceManager.h>
+
+#include <clangmetatool/match_forwarder.h>
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/source_util.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using namespace clang::ast_matchers;
+
+class MyTool {
+private:
+  clang::CompilerInstance* ci;
+  clangmetatool::MatchForwarder mf;
+  std::vector<const clang::DeclRefExpr*> data;
+
+  void handleDeclRefExpr(const MatchFinder::MatchResult& r) {
+    data.push_back(r.Nodes.getNodeAs<clang::DeclRefExpr>("ref"));
+  }
+
+public:
+  MyTool(clang::CompilerInstance* ci, MatchFinder *f)
+    : ci(ci), mf(f) {
+    using namespace std::placeholders;
+    StatementMatcher matcher = declRefExpr().bind("ref");
+    mf.addMatcher(matcher, std::bind(&MyTool::handleDeclRefExpr, this, _1));
+  }
+
+  void postProcessing
+  (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+    EXPECT_EQ(data.size(), 3);
+
+    std::vector<std::string> expected = {
+      "",
+      "VAR",
+      "VAR",
+    };
+
+    for (int i = 0; i < data.size(); ++i) {
+      EXPECT_EQ(clangmetatool::SourceUtil::getMacroNameForStatement(
+                    *data[i],
+                    ci->getSourceManager()),
+                expected[i]);
+    }
+  }
+};
+
+} // namespace anonymous
+
+TEST(propagation_MacroConstantPropagation, basic) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+  int argc = 4;
+  const char* argv[] = {
+    "foo",
+    CMAKE_SOURCE_DIR "/t/data/034-macro-name-for-statement/foo.cpp",
+    "--",
+    "-xc"
+  };
+  clang::tooling::CommonOptionsParser optionsParser
+    (argc, argv, MyToolCategory);
+  clang::tooling::RefactoringTool tool
+    (optionsParser.getCompilations(), optionsParser.getSourcePathList());
+  clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>
+    raf(tool.getReplacements());
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -50,6 +50,7 @@ foreach(
   031-validate-include-graph
   032-find-functions
   033-detect-partial-macro-expansion
+  034-macro-name-for-statement
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/data/034-macro-name-for-statement/foo.cpp
+++ b/t/data/034-macro-name-for-statement/foo.cpp
@@ -1,0 +1,27 @@
+int var;
+
+#define VAR var
+
+#define FUNC(x) (x + 1)
+
+int main(){
+  var;
+  VAR;
+  FUNC(VAR);
+}
+
+// ----------------------------------------------------------------------------
+// Copyright 2018 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------


### PR DESCRIPTION
**Describe your changes**
Macro names were not being resolved for statements that were passed as macro arguments as the code was excluding too many input statements.

**Testing performed**
Added new test `034-macro-name-for-statement`
