### PR TITLE
Fix internal build

### DIFF
--- a/t/027-c-style-variadic-integer-propagation.t.cpp
+++ b/t/027-c-style-variadic-integer-propagation.t.cpp
@@ -134,12 +134,13 @@ TEST(propagation_ConstantIntegerPropagation, functionArgs) {
   const char* argv[] = {
     "foo",
     CMAKE_SOURCE_DIR "/t/data/027-c-style-variadic-integer-propagation/main.cpp",
+
+    // Set resource dir so stdarg.h can be found
+    "-extra-arg=-resource-dir=" CLANG_RESOURCE_DIR,
+
     "--",
     // Test C++ for confirming that this works on a superset
     "-xc++",
-
-    // Set resource dir so stdarg.h can be found
-    "-resource-dir=" CLANG_RESOURCE_DIR
   };
   clang::tooling::CommonOptionsParser optionsParser
     (argc, argv, MyToolCategory);


### PR DESCRIPTION
**Describe your changes**
Pass `-resource-dir` using `-extra-arg` in tests, this fixes issues with our internal build and version of clang.

**Testing performed**
Unit tests now pass internally.
