### PR TITLE
Partial macro detection for macro as argument to macro

### DIFF
--- a/src/source_util.cpp
+++ b/src/source_util.cpp
@@ -187,6 +187,13 @@ bool SourceUtil::isPartialMacro(const clang::SourceRange &sourceRange,
   // the statement.
 
   clang::SourceLocation begin = sourceRange.getBegin();
+  clang::SourceLocation end = sourceRange.getEnd();
+
+  if (sourceManager.isMacroArgExpansion(begin) !=
+      sourceManager.isMacroArgExpansion(end)) {
+    // This catches macros which might receive other macros as arguments
+    return true; // partial macro
+  }
 
   auto usesGccVarargExtensionAtLoc = [&sourceManager,
                                       &preprocessor](const auto &loc) {
@@ -242,7 +249,6 @@ bool SourceUtil::isPartialMacro(const clang::SourceRange &sourceRange,
   // Trace through levels of macros that are expanded by the end of the
   // statement.
 
-  clang::SourceLocation end = sourceRange.getEnd();
   const clang::MacroInfo *prevMacro = nullptr;
 
   while (end.isMacroID()) {

--- a/t/data/033-detect-partial-macro-expansion/partial-macro-usages.cpp
+++ b/t/data/033-detect-partial-macro-expansion/partial-macro-usages.cpp
@@ -43,7 +43,8 @@ int positive()
     + AFTER_EXPR(4)
     + OUTER_MACRO(6)
     + VARARG_TO_VARARG_PASTED(0, 1, M_ARRAY[1])
-    + VARARG_TO_NONVARARG_PASTED(M_ARRAY[1]);
+    + VARARG_TO_NONVARARG_PASTED(M_ARRAY[1])
+    + MACRO_AS_ARG(M_ARRAY);
 }
 
 int negative() {
@@ -59,8 +60,4 @@ int negative() {
     + VARARG_TO_VARARG_DIRECT(0, M_ARRAY[1])
     + VARARG_TO_NONVARARG_DIRECT(M_ARRAY[1]);
 
-}
-
-int falseNegative() {
-  return MACRO_AS_ARG(M_ARRAY);
 }


### PR DESCRIPTION
If there is a macro of the form
```
#define ARRAY_MACRO(x) (x[0] + x[1])
```
and it is passed another macro as an argument, it is not detected as a partial macro for that case.

This change detects that. The unit tests have been updated so that this case is no longer ignored.