### PR TITLE
Support for clang 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,8 @@ matrix:
           language: cpp
           sudo: true
           script: docker build --build-arg TARGET_LLVM_VERSION=12 .
+        - os: linux
+          compiler: gcc
+          language: cpp
+          sudo: true
+          script: docker build --build-arg TARGET_LLVM_VERSION=13 .

--- a/skeleton/src/main.cpp
+++ b/skeleton/src/main.cpp
@@ -38,10 +38,15 @@ int main(int argc, const char *argv[]) {
   llvm::cl::extrahelp CommonHelp(
       clang::tooling::CommonOptionsParser::HelpMessage);
 
-  clang::tooling::CommonOptionsParser optionsParser(argc, argv, MyToolCategory);
+  auto parseResult = clang::tooling::CommonOptionsParser::create(
+      argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  if (!parseResult) {
+    llvm::errs() << parseResult.takeError();
+    return 1;
+  }
 
-  clang::tooling::RefactoringTool tool(optionsParser.getCompilations(),
-                                       optionsParser.getSourcePathList());
+  clang::tooling::RefactoringTool tool(parseResult->getCompilations(),
+                                       parseResult->getSourcePathList());
 
   MyTool::ArgTypes toolArgs;
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>> raf(

--- a/t/001-meta-tool.t.cpp
+++ b/t/001-meta-tool.t.cpp
@@ -39,10 +39,11 @@ TEST(use_meta_tool, factory) {
   int argc = 4;
   const char* argv[] = { "foo", "/dev/null", "--", "-xc++"  };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/002-includegraph-just-includes.t.cpp
+++ b/t/002-includegraph-just-includes.t.cpp
@@ -91,10 +91,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/003-includegraph-function-ref.t.cpp
+++ b/t/003-includegraph-function-ref.t.cpp
@@ -77,10 +77,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/004-variablerefs-basic.t.cpp
+++ b/t/004-variablerefs-basic.t.cpp
@@ -98,10 +98,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/005-membermethoddecls-basic.t.cpp
+++ b/t/005-membermethoddecls-basic.t.cpp
@@ -67,10 +67,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/006-gather-non-const-values.t.cpp
+++ b/t/006-gather-non-const-values.t.cpp
@@ -140,10 +140,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/007-find-calls.t.cpp
+++ b/t/007-find-calls.t.cpp
@@ -66,10 +66,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/008-definitions-two-funcs.t.cpp
+++ b/t/008-definitions-two-funcs.t.cpp
@@ -65,10 +65,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/009-definitions-one-func-in-namespace.t.cpp
+++ b/t/009-definitions-one-func-in-namespace.t.cpp
@@ -62,10 +62,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/010-definitions-two-class-defs-with-funcs.t.cpp
+++ b/t/010-definitions-two-class-defs-with-funcs.t.cpp
@@ -79,10 +79,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/011-definitions-templates.t.cpp
+++ b/t/011-definitions-templates.t.cpp
@@ -83,10 +83,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/012-references-non-template.t.cpp
+++ b/t/012-references-non-template.t.cpp
@@ -149,10 +149,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/013-references-template.t.cpp
+++ b/t/013-references-template.t.cpp
@@ -155,10 +155,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/014-meta-tool-arbitrary-args.t.cpp
+++ b/t/014-meta-tool-arbitrary-args.t.cpp
@@ -61,10 +61,11 @@ TEST(use_meta_tool, factory) {
   int argc = 4;
   const char* argv[] = { "foo", "/dev/null", "--", "-xc++"  };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/015-basic-cstring-propagation.t.cpp
+++ b/t/015-basic-cstring-propagation.t.cpp
@@ -125,8 +125,12 @@ TEST(propagation_ConstantCStringPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/016-branching-cstring-propagation.t.cpp
+++ b/t/016-branching-cstring-propagation.t.cpp
@@ -140,8 +140,12 @@ TEST(propagation_ConstantCStringPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/017-looping-cstring-propagation.t.cpp
+++ b/t/017-looping-cstring-propagation.t.cpp
@@ -126,8 +126,12 @@ TEST(propagation_ConstantCStringPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/018-multi-function-cstring-propagation.t.cpp
+++ b/t/018-multi-function-cstring-propagation.t.cpp
@@ -153,8 +153,12 @@ TEST(propagation_ConstantCStringPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/019-basic-integer-propagation.t.cpp
+++ b/t/019-basic-integer-propagation.t.cpp
@@ -125,8 +125,12 @@ TEST(propagation_ConstantIntegerPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/020-function-args-integer-propagation.t.cpp
+++ b/t/020-function-args-integer-propagation.t.cpp
@@ -129,8 +129,12 @@ TEST(propagation_ConstantIntegerPropagation, functionArgs) {
     // Test C++ for confirming that this works on a superset
     "-xc++"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/021-branching-integer-propagation.t.cpp
+++ b/t/021-branching-integer-propagation.t.cpp
@@ -135,8 +135,12 @@ TEST(propagation_ConstantIntegerPropagation, functionArgs) {
     // Test C++ for confirming that this works on a superset
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/022-looping-integer-propagation.t.cpp
+++ b/t/022-looping-integer-propagation.t.cpp
@@ -137,8 +137,12 @@ TEST(propagation_ConstantIntegerPropagation, functionArgs) {
     // Test C++ for confirming that this works on a superset
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/023-multi-function-integer-propagation.t.cpp
+++ b/t/023-multi-function-integer-propagation.t.cpp
@@ -146,8 +146,12 @@ TEST(propagation_ConstantIntegerPropagation, functionArgs) {
     // Test C++ for confirming that this works on a superset
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/024-find-cxx-member-calls.t.cpp
+++ b/t/024-find-cxx-member-calls.t.cpp
@@ -91,10 +91,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/025-find-mixed-calls.t.cpp
+++ b/t/025-find-mixed-calls.t.cpp
@@ -84,10 +84,11 @@ TEST(use_meta_tool, factory) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/026-macro-propagation.t.cpp
+++ b/t/026-macro-propagation.t.cpp
@@ -157,8 +157,12 @@ TEST(propagation_MacroConstantPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/027-c-style-variadic-integer-propagation.t.cpp
+++ b/t/027-c-style-variadic-integer-propagation.t.cpp
@@ -142,8 +142,12 @@ TEST(propagation_ConstantIntegerPropagation, functionArgs) {
     // Test C++ for confirming that this works on a superset
     "-xc++",
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/028-diagnostic-during-postprocessing.t.cpp
+++ b/t/028-diagnostic-during-postprocessing.t.cpp
@@ -61,10 +61,11 @@ TEST(diagnostic_during_postprocessing, test) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/029-tool-application-support.t.cpp
+++ b/t/029-tool-application-support.t.cpp
@@ -43,8 +43,11 @@ protected:
 
     int argc = argumentPtrs.size();
     const char** argv = argumentPtrs.data();
-    clang::tooling::CommonOptionsParser parser(argc, argv,
-                                               optionCategory());
+
+    auto result = clang::tooling::CommonOptionsParser::create(
+      argc, argv, optionCategory(), llvm::cl::OneOrMore);
+    EXPECT_TRUE(!!result);
+    clang::tooling::CommonOptionsParser& parser = result.get();
 
     // ToolApplicationSupport::verifyInstallation crashes with exit(1)
     // if the required headers aren't found
@@ -179,8 +182,10 @@ TEST(suppress_warnings, test)
   };
   int argc = sizeof argv / sizeof *argv;
 
-  clang::tooling::CommonOptionsParser optionsParser
-    ( argc, argv, optionCategory() );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, optionCategory(), llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
 
   // We can't rely on 'optionsParser.getSourcePathList' because it is not
   // reset between invocations, so has all of the bogus paths from the other

--- a/t/030-cstring-propagation-bug.t.cpp
+++ b/t/030-cstring-propagation-bug.t.cpp
@@ -125,8 +125,12 @@ TEST(propagation_ConstantCStringPropagation, basic) {
     "--",
     "-xcpp"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/031-validate-include-graph.t.cpp
+++ b/t/031-validate-include-graph.t.cpp
@@ -204,7 +204,10 @@ TEST(include_validate_test, basic) {
       "foo", CMAKE_SOURCE_DIR "/t/data/031-validate-include-graph/foo.cpp",
       "--", "-xc++"};
 
-  clang::tooling::CommonOptionsParser optionsParser(argc, argv, MyToolCategory);
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
 
   clang::tooling::RefactoringTool tool(optionsParser.getCompilations(),
                                        optionsParser.getSourcePathList());

--- a/t/032-find-functions.t.cpp
+++ b/t/032-find-functions.t.cpp
@@ -55,10 +55,11 @@ void runTool(const std::string& file, MyTool::ArgTypes& fns) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/033-detect-partial-macro-expansion.t.cpp
+++ b/t/033-detect-partial-macro-expansion.t.cpp
@@ -96,7 +96,10 @@ TEST(partialMacroExpansion_Detect, positive) {
       "/t/data/033-detect-partial-macro-expansion/partial-macro-usages.cpp",
       "--", "-xc++"};
 
-  clang::tooling::CommonOptionsParser optionsParser(argc, argv, category);
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, category, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
   clang::tooling::RefactoringTool tool(optionsParser.getCompilations(),
                                        optionsParser.getSourcePathList());
   std::string positive("positive");
@@ -115,7 +118,10 @@ TEST(partialMacroExpansion_Detect, negative) {
       "/t/data/033-detect-partial-macro-expansion/partial-macro-usages.cpp",
       "--", "-xc++"};
 
-  clang::tooling::CommonOptionsParser optionsParser(argc, argv, category);
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, category, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
   clang::tooling::RefactoringTool tool(optionsParser.getCompilations(),
                                        optionsParser.getSourcePathList());
   std::string negative("negative");
@@ -134,7 +140,10 @@ TEST(partialMacroExpansion_Detect, DISABLED_FalseNegatives) {
       "/t/data/033-detect-partial-macro-expansion/partial-macro-usages.cpp",
       "--", "-xc++"};
 
-  clang::tooling::CommonOptionsParser optionsParser(argc, argv, category);
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, category, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
   clang::tooling::RefactoringTool tool(optionsParser.getCompilations(),
                                        optionsParser.getSourcePathList());
   std::string negative("falseNegative");

--- a/t/034-macro-name-for-statement.t.cpp
+++ b/t/034-macro-name-for-statement.t.cpp
@@ -78,8 +78,12 @@ TEST(propagation_MacroConstantPropagation, basic) {
     "--",
     "-xc"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/035-range-for-statement.t.cpp
+++ b/t/035-range-for-statement.t.cpp
@@ -101,8 +101,12 @@ TEST(propagation_MacroConstantPropagation, basic) {
     "-xc",
     "-Wno-unused-value"
   };
-  clang::tooling::CommonOptionsParser optionsParser
-    (argc, argv, MyToolCategory);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     (optionsParser.getCompilations(), optionsParser.getSourcePathList());
   clangmetatool::MetaToolFactory<clangmetatool::MetaTool<MyTool>>

--- a/t/036-export-fixes-output.t.cpp
+++ b/t/036-export-fixes-output.t.cpp
@@ -65,10 +65,11 @@ TEST(ValidateOutput, sourceAndHeaderFile) {
     "-xc++"
   };
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/037-includegraph-dependency-check.t.cpp
+++ b/t/037-includegraph-dependency-check.t.cpp
@@ -47,10 +47,11 @@ TEST(use_meta_tool, factory) {
   };
   int argc = sizeof(argv) / sizeof(argv[0]);
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/038-includegraph-nested-name.t.cpp
+++ b/t/038-includegraph-nested-name.t.cpp
@@ -43,10 +43,11 @@ TEST(use_meta_tool, factory) {
   };
   int argc = sizeof(argv) / sizeof(argv[0]);
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/039-includegraph-nested-name-parameter.t.cpp
+++ b/t/039-includegraph-nested-name-parameter.t.cpp
@@ -43,10 +43,11 @@ TEST(use_meta_tool, factory) {
   };
   int argc = sizeof(argv) / sizeof(argv[0]);
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());

--- a/t/040-includegraph-nested-using.t.cpp
+++ b/t/040-includegraph-nested-using.t.cpp
@@ -52,10 +52,11 @@ TEST(use_meta_tool, factory) {
   };
   int argc = sizeof(argv) / sizeof(argv[0]);
 
-  clang::tooling::CommonOptionsParser
-    optionsParser
-    ( argc, argv,
-      MyToolCategory );
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
   clang::tooling::RefactoringTool tool
     ( optionsParser.getCompilations(),
       optionsParser.getSourcePathList());


### PR DESCRIPTION
ENG2STAAR-3298

**Describe your changes**
Add support for clang 13.

**Testing performed**
Run unit tests

**Additional context**
The `CommonOptionsParser` constructor was made private in clang 13, so this required a change in a lot of files as that is part of the basic initialization of a clang tool.