### PR TITLE
Include graph backup restore state

### DIFF
--- a/include/clangmetatool/include_graph_dependencies.h
+++ b/include/clangmetatool/include_graph_dependencies.h
@@ -46,6 +46,15 @@ struct IncludeGraphDependencies {
   static std::set<clangmetatool::types::FileUID>
   liveDependencies(const clangmetatool::collectors::IncludeGraphData *data,
                    const clangmetatool::types::FileUID &headerFUID);
+
+  /**
+   * Backup state of IncludeGraphData
+   */
+  static void backup(collectors::IncludeGraphData*);
+  /**
+   * Restore state of IncludeGraphData
+   */
+  static void restore(collectors::IncludeGraphData*);
 }; // struct IncludeGraphDependencies
 } // namespace clangmetatool
 

--- a/src/include_graph_dependencies.cpp
+++ b/src/include_graph_dependencies.cpp
@@ -5,6 +5,10 @@
 namespace clangmetatool {
 
 namespace {
+  
+// Backup copy of usage_reference_count, only used for internal implementation
+std::map<clangmetatool::types::FileGraphEdge, size_t> usage_reference_count_bk;
+
 
 // Returns a range of edges whose source vertex matches the given file uid
 inline std::pair<types::FileGraph::const_iterator,
@@ -76,7 +80,7 @@ bool requires(const collectors::IncludeGraphData *data,
 
   return keepEdge;
 }
-} // namespace
+} // anonymous namespace
 
 bool IncludeGraphDependencies::decrementUsageRefCount(
     collectors::IncludeGraphData *data,
@@ -138,4 +142,13 @@ std::set<types::FileUID> IncludeGraphDependencies::liveDependencies(
 
   return dependencies;
 }
+
+void IncludeGraphDependencies::backup(collectors::IncludeGraphData* data){
+  usage_reference_count_bk = data->usage_reference_count;
+}
+
+void IncludeGraphDependencies::restore(collectors::IncludeGraphData* data){
+  data->usage_reference_count = usage_reference_count_bk;
+}
+
 } // namespace clangmetatool

--- a/t/042-includegraph-reset-state.t.cpp
+++ b/t/042-includegraph-reset-state.t.cpp
@@ -1,0 +1,113 @@
+#include "clangmetatool-testconfig.h"
+
+#include <gtest/gtest.h>
+
+#include <clangmetatool/meta_tool_factory.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/collectors/include_graph.h>
+#include <clangmetatool/include_graph_dependencies.h>
+
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Tooling.h>
+#include <clang/Tooling/Refactoring.h>
+#include <llvm/Support/CommandLine.h>
+
+class MyTool {
+private:
+  clang::CompilerInstance* ci;
+  clangmetatool::collectors::IncludeGraph graph;
+public:
+  MyTool(clang::CompilerInstance* ci, clang::ast_matchers::MatchFinder *f)
+    :ci(ci), graph(ci, f) {
+  }
+  void postProcessing
+  (std::map<std::string, clang::tooling::Replacements> &replacementsMap) {
+    clangmetatool::collectors::IncludeGraphData *data = graph.getData();
+
+    clangmetatool::types::FileUID header = 0;
+    clangmetatool::types::FileUID cpp = 0;
+    for(auto itr = data->fuid2name.cbegin(); itr != data->fuid2name.cend(); ++itr){
+      if(itr->second == "foo.h"){
+        header = itr->first;
+      }
+      if(itr->second == "foo.cpp"){
+        cpp = itr->first;
+      }
+    }
+    auto edge = std::make_pair(cpp, header);
+    size_t edge_rc = 4; // edge initial reference count
+
+    // validator that validate the edge and its reference count
+    // before and after doing decrementUsageRefCount
+    auto validator = [&](){
+      ASSERT_EQ(data->usage_reference_count.count(edge), 1);
+      ASSERT_EQ(data->usage_reference_count[edge], edge_rc);
+      clangmetatool::IncludeGraphDependencies::decrementUsageRefCount(data, edge);
+      ASSERT_EQ(data->usage_reference_count[edge], edge_rc - 1);
+      clangmetatool::IncludeGraphDependencies::decrementUsageRefCount(data, edge);
+      ASSERT_EQ(data->usage_reference_count[edge], edge_rc - 2);
+    };
+
+    // backup and validate the initial state 
+    clangmetatool::IncludeGraphDependencies::backup(data);
+    validator();
+    
+    // validate that the include graph is able to be restored
+    clangmetatool::IncludeGraphDependencies::restore(data);
+    validator();
+    
+    // validate that the include graph is able to be backup at a specific state
+    // and restored back to that state
+    clangmetatool::IncludeGraphDependencies::restore(data);
+    clangmetatool::IncludeGraphDependencies::decrementUsageRefCount(data, edge);
+    edge_rc = 3;
+    clangmetatool::IncludeGraphDependencies::backup(data);
+    validator();
+  }
+};
+
+TEST(use_meta_tool, factory) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+
+  const char* argv[] = {
+    "foo",
+    CMAKE_SOURCE_DIR "/t/data/042-includegraph-reset-state/foo.cpp",
+    "--",
+    "-xc++"
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+    argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser& optionsParser = result.get();
+
+  clang::tooling::RefactoringTool tool
+    ( optionsParser.getCompilations(),
+      optionsParser.getSourcePathList());
+
+  clangmetatool::MetaToolFactory< clangmetatool::MetaTool<MyTool> >
+    raf(tool.getReplacements());
+
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}
+
+
+// ----------------------------------------------------------------------------
+// Copyright 2021 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ----------------------------- END-OF-FILE ----------------------------------

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -58,6 +58,7 @@ foreach(
   039-includegraph-nested-name-parameter
   040-includegraph-nested-using
   041-expand-range-if-valid
+  042-includegraph-reset-state
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/data/042-includegraph-reset-state/foo.cpp
+++ b/t/data/042-includegraph-reset-state/foo.cpp
@@ -1,0 +1,13 @@
+#include "foo.h"
+
+void foo(){}
+
+int main(){
+   internal_int retry = RETRY_COUNT;
+   internal_int count = 3;
+   while(count < retry){
+     foo();
+     count++;
+   }
+   return 0;
+}

--- a/t/data/042-includegraph-reset-state/foo.h
+++ b/t/data/042-includegraph-reset-state/foo.h
@@ -1,0 +1,13 @@
+#ifndef FOO_H
+#define FOO_H
+
+// macro
+#define RETRY_COUNT 300
+
+// type
+typedef int internal_int;
+
+// decl
+void foo();
+
+#endif


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**

The state of include graph can be changed by `IncludeGraphDependencies`(for example `decrementReferenceCount`)

This PR adds support to reset state of include graph

**Testing performed**

In the test we change the include graph by decreasing the reference count, and then do `reset` to reset state and verify the include graph rollback to initial state after doing `reset`

**Additional context**
The motivation of having this feature is that we need to modify include statements in different contexts and they are independent. So that we need to have a way to reset include graph state when finishing one context and then going to another