### PR TITLE
Request support for C language in top-level CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,9 @@ matrix:
           language: cpp
           sudo: true
           script: docker build --build-arg TARGET_LLVM_VERSION=13 .
+        - os: linux
+          dist: jammy
+          compiler: gcc
+          language: cpp
+          sudo: true
+          script: docker build --build-arg TARGET_LLVM_VERSION=14 --build-arg BASE_IMAGE=ubuntu:22.04 --build-arg GCC_VERSION=9 --build-arg IMAGE_REPO=jammy .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 
-project(clangmetatool CXX)
+project(clangmetatool C CXX)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV CC=/usr/bin/gcc-"$GCC_VERSION" \
 # Install gtest as they recommend to, for 1.8.x
 RUN cd /usr/src/gtest && \
     cmake . && \
-    make ; \
+    make && \
     find . -name "libg*" -exec mv {} /usr/lib \;
 
 COPY . clangmetatool/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM $BASE_IMAGE
 
 ARG TARGET_LLVM_VERSION=8
 ARG IMAGE_REPO=bionic
+ARG GCC_VERSION=7
 
 # Depenedencies to fetch, build llvm and clang
 RUN apt-get update && apt-get install -y \
@@ -20,8 +21,8 @@ RUN apt-get update
 
 RUN apt-get install -y \
         # Build toolchains that we are targeting for compatibility with
-        gcc-7 \
-        g++-7 \
+        gcc-"$GCC_VERSION" \
+        g++-"$GCC_VERSION" \
         cmake \
         # clangmetatool uses gtest
         libgtest-dev \
@@ -42,16 +43,16 @@ RUN apt-get install -y \
         libc++-"$TARGET_LLVM_VERSION"-dev
 
 # Set up build environment
-ENV CC=/usr/bin/gcc-7 \
-    CXX=/usr/bin/g++-7 \
+ENV CC=/usr/bin/gcc-"$GCC_VERSION" \
+    CXX=/usr/bin/g++-"$GCC_VERSION" \
     MAKEFLAGS="-j4" \
     CMAKE_BUILD_PARALLEL_LEVEL=4
 
 # Install gtest as they recommend to, for 1.8.x
 RUN cd /usr/src/gtest && \
     cmake . && \
-    make && \
-    mv libg* /usr/lib
+    make ; \
+    find . -name "libg*" -exec mv {} /usr/lib \;
 
 COPY . clangmetatool/
 WORKDIR clangmetatool

--- a/t/029-tool-application-support.t.cpp
+++ b/t/029-tool-application-support.t.cpp
@@ -97,7 +97,7 @@ TEST_F(ToolApplicationSupportTest, ARCH_DEPENDENT(GCCToolChain))
   ASSERT_DEATH(
       verifyInstallation({"tool", "test.cpp", "--",
                           "-resource-dir", CLANG_RESOURCE_DIR,
-                          "-gcc-toolchain", "/non-existent/123"}),
+                          "--gcc-toolchain=/non-existent/123"}),
       messageRegex);
 }
 
@@ -116,7 +116,7 @@ TEST_F(ToolApplicationSupportTest, ARCH_DEPENDENT(CFilesWithGCCToolChain))
   ASSERT_DEATH(
       verifyInstallation({"tool", "test.c", "--",
                           "-resource-dir", CLANG_RESOURCE_DIR,
-                          "-gcc-toolchain", "/non-existent/123"}),
+                          "--gcc-toolchain=/non-existent/123"}),
       messageRegex);
 }
 


### PR DESCRIPTION
There is a problem building `clangmetatool` with llvm14 — it requires `C` language enabled in CMake.

**Describe your changes**
Add C language to the `project` command of the top-level CMakeLists.txt

**Testing performed**

`clangmetatool` was successfully rebuilt with llvm 12, llvm 13, and llvm 14.

**Additional context**

The build error without the patch

```console
CMake Error at /opt/bb/share/cmake-3.24/Modules/Internal/CheckSourceCompiles.cmake:44 (message):
check_source_compiles: C: needs to be enabled before use.
```

See also https://github.com/llvm/llvm-project/issues/53950