### PR TITLE
Match a type usage and its declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,6 @@ matrix:
           compiler: gcc
           language: cpp
           sudo: true
-          script: docker build --build-arg TARGET_LLVM_VERSION=8 .
-        - os: linux
-          compiler: gcc
-          language: cpp
-          sudo: true
-          script: docker build --build-arg TARGET_LLVM_VERSION=9 .
-        - os: linux
-          compiler: gcc
-          language: cpp
-          sudo: true
           script: docker build --build-arg TARGET_LLVM_VERSION=10 .
         - os: linux
           compiler: gcc

--- a/src/collectors/include_graph/find_type_match_callback.cpp
+++ b/src/collectors/include_graph/find_type_match_callback.cpp
@@ -49,8 +49,8 @@ void FindTypeMatchCallback::run(
     const clang::ast_matchers::MatchFinder::MatchResult &r) {
 
   if (const clang::TypeLoc *tl = r.Nodes.getNodeAs<clang::TypeLoc>("type")) {
-
-    add_type_reference(ci, data, tl);
+    const clang::Decl* decl = r.Nodes.getNodeAs<clang::Decl>("decl");
+    add_type_reference(ci, data, tl, decl);
   }
 }
 } // namespace include_graph

--- a/src/collectors/include_graph/include_graph.cpp
+++ b/src/collectors/include_graph/include_graph.cpp
@@ -48,6 +48,7 @@
 namespace clangmetatool {
 namespace collectors {
 
+using namespace clang::ast_matchers;
 class IncludeGraphImpl {
 private:
   clang::CompilerInstance *ci;
@@ -56,7 +57,7 @@ private:
   clang::ast_matchers::StatementMatcher sm1 =
       clang::ast_matchers::declRefExpr().bind("ref");
   clang::ast_matchers::TypeLocMatcher sm2 =
-      clang::ast_matchers::typeLoc().bind("type");
+      clang::ast_matchers::typeLoc(optionally(loc((const internal::Matcher<clang::QualType> &)hasDeclaration(decl().bind("decl"))))).bind("type");
   clang::ast_matchers::DeclarationMatcher sm3 =
       clang::ast_matchers::decl().bind("decl");
 

--- a/src/collectors/include_graph/include_graph_util.cpp
+++ b/src/collectors/include_graph/include_graph_util.cpp
@@ -233,10 +233,9 @@ bool check_for_first_end(clang::CompilerInstance *ci, IncludeGraphData *data,
 }
 
 void add_type_reference(clang::CompilerInstance *ci, IncludeGraphData *data,
-                        const clang::TypeLoc *n) {
+                        const clang::TypeLoc *n, const clang::Decl* decl) {
 
   const clang::Type *t = n->getTypePtr();
-  const clang::Decl *decl = NULL;
   if (!decl)
     decl = extract_decl_for_type<clang::TypedefType>(t);
   if (!decl)

--- a/src/collectors/include_graph/include_graph_util.h
+++ b/src/collectors/include_graph/include_graph_util.h
@@ -41,7 +41,7 @@ void add_decl_reference(clang::CompilerInstance *ci, IncludeGraphData *data,
                         const clang::DeclRefExpr *n);
 
 void add_type_reference(clang::CompilerInstance *ci, IncludeGraphData *data,
-                        const clang::TypeLoc *n);
+                        const clang::TypeLoc *n, const clang::Decl* decl);
 } // namespace include_graph
 } // namespace collectors
 } // namespace clangmetatool

--- a/t/042-generic-using-include-graph.t.cpp
+++ b/t/042-generic-using-include-graph.t.cpp
@@ -1,0 +1,86 @@
+#include "clangmetatool-testconfig.h"
+
+
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include <iostream>
+
+#include <clangmetatool/collectors/include_graph.h>
+#include <clangmetatool/collectors/include_graph_data.h>
+#include <clangmetatool/include_graph_dependencies.h>
+#include <clangmetatool/meta_tool.h>
+#include <clangmetatool/meta_tool_factory.h>
+
+#include <clang/Frontend/FrontendAction.h>
+#include <clang/Tooling/CommonOptionsParser.h>
+#include <clang/Tooling/Core/Replacement.h>
+#include <clang/Tooling/Refactoring.h>
+#include <clang/Tooling/Tooling.h>
+#include <llvm/Support/CommandLine.h>
+
+class WeakDependenciesTool {
+private:
+  clang::CompilerInstance *ci;
+  clangmetatool::collectors::IncludeGraph includeGraph;
+
+public:
+  WeakDependenciesTool(clang::CompilerInstance *ci,
+                       clang::ast_matchers::MatchFinder *f)
+      : ci(ci), includeGraph(ci, f) {}
+  void postProcessing(
+      std::map<std::string, clang::tooling::Replacements> &replacementMap) {
+    clangmetatool::collectors::IncludeGraphData *data = includeGraph.getData();
+
+    std::map<std::string, clangmetatool::types::FileUID> fname2uid;
+    for (auto itr = data->fuid2name.begin(); itr != data->fuid2name.end();
+         ++itr) {
+      fname2uid[itr->second] = itr->first;
+    }
+
+    // Get main file UID
+    clang::SourceManager &sm = ci->getSourceManager();
+    const clang::FileEntry *mfe = sm.getFileEntryForID(sm.getMainFileID());
+    clangmetatool::types::FileUID mfid = mfe->getUID();
+    EXPECT_EQ(
+        clangmetatool::IncludeGraphDependencies::DirectDependenciesMap(
+            {std::make_pair(
+                 fname2uid["generic_using.h"],
+                 std::set<clangmetatool::types::FileUID>{fname2uid["generic_using.h"]})}),
+        clangmetatool::IncludeGraphDependencies::liveWeakDependencies(data,
+                                                                      mfid));
+
+    clangmetatool::IncludeGraphDependencies::decrementUsageRefCount(
+        data, {mfid, fname2uid["generic_using.h"]});
+
+    // generic_using.h no longer needed
+    EXPECT_EQ(
+        clangmetatool::IncludeGraphDependencies::DirectDependenciesMap({}),
+        clangmetatool::IncludeGraphDependencies::liveWeakDependencies(data,
+                                                                      mfid));
+
+  }
+};
+
+TEST(include_validate_test, liveWeakDependencies) {
+  llvm::cl::OptionCategory MyToolCategory("my-tool options");
+
+  int argc = 4;
+  const char *argv[] = {
+      "foo", CMAKE_SOURCE_DIR "/t/data/042-generic-using-include-graph/foo.cpp",
+      "--", "-xc++"};
+
+  auto result = clang::tooling::CommonOptionsParser::create(
+      argc, argv, MyToolCategory, llvm::cl::OneOrMore);
+  ASSERT_TRUE(!!result);
+  clang::tooling::CommonOptionsParser &optionsParser = result.get();
+
+  clang::tooling::RefactoringTool tool(optionsParser.getCompilations(),
+                                       optionsParser.getSourcePathList());
+
+  clangmetatool::MetaToolFactory<clangmetatool::MetaTool<WeakDependenciesTool>>
+      raf(tool.getReplacements());
+
+  int r = tool.runAndSave(&raf);
+  ASSERT_EQ(0, r);
+}

--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -58,6 +58,7 @@ foreach(
   039-includegraph-nested-name-parameter
   040-includegraph-nested-using
   041-expand-range-if-valid
+  042-generic-using-include-graph
   )
 
   add_executable(${TEST}.t ${TEST}.t.cpp)

--- a/t/data/042-generic-using-include-graph/foo.cpp
+++ b/t/data/042-generic-using-include-graph/foo.cpp
@@ -1,0 +1,5 @@
+#include "generic_using.h"
+
+void func() {
+  generic_using<int> td;
+}

--- a/t/data/042-generic-using-include-graph/generic_type.h
+++ b/t/data/042-generic-using-include-graph/generic_type.h
@@ -1,0 +1,6 @@
+#pragma once
+
+template <typename T>
+struct generic_type {
+  T val;
+};

--- a/t/data/042-generic-using-include-graph/generic_using.h
+++ b/t/data/042-generic-using-include-graph/generic_using.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "generic_type.h"
+
+template <typename T>
+using generic_using = generic_type<T>;


### PR DESCRIPTION
When a type alias is added for a generic type (via a using statement) the include graph currently doesn't record the usage of the type alias but only of the underlying type.

**Given the usage of myvec below**
```cpp
#include "myvec.h"

void func() {
  myvec<int> mv;
}
```

And the declaration of myvec in the header `myvec.h`
```c++
#pragma once

#include <vector>

template <typename T>
using myvec = std::vector<T>;
```

clangmetatool will not notice that `myvec.h` is used at all.

It tries to find the declaration of `myvec` but ends up finding the declaration of `std::vector` (see https://github.com/bloomberg/clangmetatool/blob/cb17e415ffbc6b98c2f307f2aaff4be5cd56af0a/src/collectors/include_graph/include_graph_util.cpp#L240-L259).

This PR fixes this by matching both the usage of type and its declaration. 

**Testing performed**
See the attached test case


Signed-off-by: Kojo Adams kadams85@bloomberg.net