### PR TITLE
Correctly find the location when a macro is called within a macro

### DIFF
--- a/t/data/044-type-access-through-expansion/foo.cpp
+++ b/t/data/044-type-access-through-expansion/foo.cpp
@@ -1,8 +1,10 @@
 #include "foo.h"
 #include "macro.h"
 
+#define CALL_FOO2(v) FOO2(v)
+
 void function() {
   FOO1() f1;
   FOO2(v);
-  FOO1() f3;
+  CALL_FOO2(f3);
 }


### PR DESCRIPTION
Assuming we have the following code
```cpp

int main() {
  call_print_foo();
}
```

The current code doesn't note that reference to print_foo() since it happens in `scratch space`. This PR adds support for it.
