### PR TITLE
fix: Issue #81: tests do not build with FetchContent

### DIFF
--- a/t/CMakeLists.txt
+++ b/t/CMakeLists.txt
@@ -67,8 +67,8 @@ foreach(
   target_include_directories(
     ${TEST}.t
     PRIVATE
-    ${CMAKE_BINARY_DIR}/t/include
-    ${CMAKE_SOURCE_DIR}/t/include
+    ${CMAKE_CURRENT_BINARY_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${LLVM_INCLUDE_DIR}>
   )


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #81*

**Describe your changes**
Replacing the root CMake project directories by the directories of the current project enables the integration of clangmetatool using CMake's FetchContent facility.

**Testing performed**
The project was successfully built as stand-alone project as well as sub-project through CMake’s FetchContent. All automated tests passed.