### PR TITLE
Add LLVM 22 support.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang-20 llvm-20-dev libclang-20-dev \
+          libc++-20-dev libgtest-dev libgmock-dev cmake
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: cpp
+        build-mode: manual
+
+    - name: Build
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_CXX_COMPILER=clang++-20 \
+              -DClang_DIR=/usr/lib/llvm-20/lib/cmake/clang \
+              ..
+        make -j$(nproc)
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,8 @@ jobs:
 
     - name: Build
       run: |
+        export CC=gcc-12                                                                                                                                                                                                                                                                                                 
+        export CXX=g++-12 
         mkdir build && cd build
         cmake -DCMAKE_CXX_COMPILER=clang++-20 \
               -DClang_DIR=/usr/lib/llvm-20/lib/cmake/clang \

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ services:
 matrix:
     include:
         - os: linux
+          dist: noble
+          compiler: gcc
+          language: cpp
+          sudo: true
+          script: docker build --progress plain --build-arg TARGET_LLVM_VERSION=22 --build-arg BASE_IMAGE=ubuntu:24.04 --build-arg GCC_VERSION=12 --build-arg IMAGE_REPO=noble .
+        - os: linux
           compiler: gcc
           language: cpp
           sudo: true

--- a/src/collectors/include_graph/include_finder.cpp
+++ b/src/collectors/include_graph/include_finder.cpp
@@ -76,7 +76,14 @@ void IncludeFinder::InclusionDirective(
 
   // The filetype characteristic is unused for now, hence marked with
   // a trailing '_'. We are recording all filetypes
-#if LLVM_VERSION_MAJOR >= 15
+#if LLVM_VERSION_MAJOR >= 22
+  if(file.has_value()) {
+    add_include_statement(ci, data, hashLoc, includeToken, filename, isAngled,
+                          filenameRange, &file->getFileEntry(),
+                          searchPath, relativePath,
+                          imported);
+  }
+#elif LLVM_VERSION_MAJOR >= 15
   if(file.has_value()) {
     add_include_statement(ci, data, hashLoc, includeToken, filename, isAngled,
                           filenameRange, &file.value().getFileEntry(),


### PR DESCRIPTION
Issue number of the reported bug or feature request: #

Describe your changes
Enable LLVM 22 in CI, add necessary workarounds for clangmetatool to be build with LLVM 22.

Testing performed
Compilation + testing suite.